### PR TITLE
Use cmake to build syzkaller

### DIFF
--- a/bm-generator/00_init.sh
+++ b/bm-generator/00_init.sh
@@ -60,6 +60,3 @@ if [ ${CUR_MAJ} -eq ${GO_VER_REQ_MAJ} ]; then
         exit 1
     fi
 fi
-
-cmake -S. -Bbuild
-cmake --build build

--- a/bm-generator/01_build.sh
+++ b/bm-generator/01_build.sh
@@ -22,19 +22,8 @@ if [ ! -d "${DIR_SYZ_SRC}" ]; then
  DIR_SYZ_SRC=$(${SCRIPT_SYZ_SRC})
   if [ ! -d "${DIR_SYZ_SRC}" ]; then
     echo "Failed setting up syzkaller sources."
-    echo "If the syzkaller source dir is not beneath $(pwd), then run this script as:"
+    echo "If the syzkaller source dir is not beneath $(pwd)/build, then run this script as:"
     echo "  DIR_SYZ_SRC=</path/to/syzkaller/source> $0"
     exit 1
   fi
 fi
-
-cd "${DIR_SYZ_SRC}"
-
-TOOLS="trace2syz prog2c extraction"
-
-make
-#make generate_trace2syz
-
-for tool in ${TOOLS}; do
-    (cd tools/syz-${tool} && go build)
-done

--- a/bm-generator/CMakeLists.txt
+++ b/bm-generator/CMakeLists.txt
@@ -19,3 +19,35 @@ FetchContent_Declare(
   GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(syzkaller)
+
+FetchContent_GetProperties(syzkaller
+  SOURCE_DIR syzkaller_SOURCE_DIR
+)
+
+find_program(GO_EXECUTABLE go)
+if(NOT GO_EXECUTABLE)
+    message(FATAL_ERROR "Go compiler not found. Please install Go.")
+endif()
+message(STATUS "Go found at: ${GO_EXECUTABLE}")
+
+# build syzkaller
+add_custom_target(syzkaller ALL
+    COMMAND make
+    WORKING_DIRECTORY ${syzkaller_SOURCE_DIR}
+)
+
+set(TOOLS_DIR "${syzkaller_SOURCE_DIR}/tools")
+# Tools we want to build of syzkaller
+set(TOOLS trace2syz prog2c extraction)
+# Build each tool
+foreach(TOOL IN ITEMS ${TOOLS})
+    set(TOOL_NAME syz-${TOOL})
+    message(STATUS "Building syzkaller tool: ${TOOL_NAME}")
+    add_custom_target(${TOOL} ALL
+        COMMAND go build
+        WORKING_DIRECTORY "${TOOLS_DIR}/${TOOL_NAME}"
+    )
+endforeach(TOOL in ${TOOLS})
+
+# Save syzkaller path to a file.
+file(WRITE "${CMAKE_BINARY_DIR}/syzkaller-path.txt" "${syzkaller_SOURCE_DIR}")

--- a/bm-generator/helper/find_syzkaller_src.sh
+++ b/bm-generator/helper/find_syzkaller_src.sh
@@ -2,16 +2,12 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+BUILD_DIR="build"
+DIR_FILE="${BUILD_DIR}/syzkaller-path.txt"
 
-DIR_BUILD=`find . -type d -name CMakeFiles |        \
-     awk 'BEGIN { OFS="\t" }{print length,$0}'  |   \
-     sort -n |                                      \
-     head -1 |                                      \
-     cut -f 2 |                                     \
-     sed 's/CMakeFiles$//'`
-
-SYZ_SRC="${DIR_BUILD}/_deps/syzkaller-src"
-
-if [ -d "${SYZ_SRC}" ]; then
-     echo "${SYZ_SRC}"
+if [ -f "${DIR_FILE}" ]; then
+     SYZKALLER_DIR=$(cat "${DIR_FILE}")
+     echo $SYZKALLER_DIR
 fi
+
+

--- a/bm-generator/test.sh
+++ b/bm-generator/test.sh
@@ -5,8 +5,7 @@ set -e
 
 STRACE_LOG="ls_strace.log"
 APP="ls"
-strace -o ${STRACE_LOG} -a 1 -s 65500 -v -xx -f -Xraw --raw=wait4 ${APP}
-
+FILE_LOG=${STRACE_LOG} helper/collect_strace.sh ${APP}
 ./00_init.sh
 ./01_build.sh
 ./02_parse.sh ${STRACE_LOG}


### PR DESCRIPTION
Change

- use cmake to build all relevant syzkaller targets
- let cmake write syzkaller source path in a file
- let `find_syzkaller_src.sh` read the path file instead of searching
- remove manual building from `01_build`
- let `test.sh` use `collect-strace.sh` script