### PR TITLE
actions: openEuler: compress docker image to make it faster

### DIFF
--- a/.github/workflows/openeuler.yml
+++ b/.github/workflows/openeuler.yml
@@ -10,7 +10,8 @@ on:
 env:
   TEST_IMG: openeuler-csb-image
   TEST_TAG: openeuler-csb:aarch64
-  TEST_TAR: openeuler-csb-aarch64.tar
+  TEST_ZST: openeuler-csb.tar.zst
+
 
 jobs:
   #
@@ -26,25 +27,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/build-push-action@v6
-        name: build openEuler container
-        with:
-          context: .
-          file: .github/workflows/openeuler/Dockerfile
-          tags: ${{ env.TEST_TAG }}
-          load: true
-          build-args:
-            BASE_IMAGE=openeuler/openeuler:24.03-lts-sp3
+      - name: build openEuler container
+        run: |
+          docker buildx build \
+            --load \
+            -t ${{ env.TEST_TAG }} -f .github/workflows/openeuler/Dockerfile .
 
-      - name: Save image
-        run: docker save  ${{ env.TEST_TAG }} -o  ${{ env.TEST_TAR }}
+          docker save ${{ env.TEST_TAG }} | zstd -T0 -19 -o ${{ env.TEST_ZST }}
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TEST_IMG }}
-          path: ${{ env.TEST_TAR }}
-
+          path: ${{ env.TEST_ZST }}
+          retention-days: 1
 
   #
   # Run tests on openEuler via openeuler-csb image
@@ -73,7 +69,8 @@ jobs:
           name: ${{ env.TEST_IMG }}
 
       - name: Load Docker image
-        run: docker load -i ${{ env.TEST_TAR }}
+        run: |
+          zstd -d -T0 ${{ env.TEST_ZST }} -c | docker load
 
       - name: Test ${{ matrix.test }}
         run: |


### PR DESCRIPTION
Use zstd to compress image before save/load. This should speedup CI run time a little bit.
