### PR TITLE
[PoC] Create docker based on a spec

### DIFF
--- a/bm-runner/bm_container.py
+++ b/bm-runner/bm_container.py
@@ -26,6 +26,7 @@ class Container(ExecutionUnit):
         self,
         idx,
         image,
+        image_matches_host,
         home_dir,
         core_set,
         record_data_dir,
@@ -36,6 +37,7 @@ class Container(ExecutionUnit):
         super().__init__(idx=idx, type=ExecutionType.CONTAINER, home_dir=home_dir, app=app)
         self.client = docker.from_env()  # Initialize Docker client
         self.image = image
+        self.image_matches_host = image_matches_host
         self.core_set = core_set
         self.record_data_dir = record_data_dir
         self.port = port + self.idx if port else None
@@ -176,17 +178,24 @@ class Container(ExecutionUnit):
 
         volumes = {
             host_home_dir: {"bind": "/home", "mode": "rw"},
-            "/usr": {"bind": "/usr", "mode": "rw"},
-            "/mnt": {"bind": "/mnt", "mode": "rw"},
             "/lib/modules": {"bind": "/lib/modules", "mode": "rw"},
             "/etc": {"bind": "/etc", "mode": "rw"},
         }
+
+        if self.image_matches_host:
+            volumes.update(
+                {
+                    "/usr": {"bind": "/usr", "mode": "rw"},
+                    "/mnt": {"bind": "/mnt", "mode": "rw"},
+                }
+            )
 
         bm_log(f"Starting Container: {self.name}")
         try:
             ports = {f"{self.port}/tcp": ("0.0.0.0", self.port)} if self.port else None
             container = self.client.containers.run(
                 image=self.image,
+                image_matches_host=self.image_matches_host,
                 command=["bash", "-c", commands],
                 name=self.name,
                 cpuset_cpus=self.core_set,
@@ -247,6 +256,7 @@ class Containers(Executer):
                 idx=i,
                 home_dir=home_dir,
                 image=config.image,
+                image_matches_host=config.image_matches_host,
                 core_set=core_set,
                 record_data_dir=record_data_dir,
                 port=config.port,

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -76,7 +76,14 @@ class ContainersConfig(dict):
         self.topo = Topology()
         self.core_count = core_count
         self.policy = CoreAssignPolicy.from_dict(core_assignment_policy)
-        self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
+
+        if image is None:
+            self.image = self.DEFAULT_IMG[get_os()]
+            self.image_matches_host = True
+        else:
+            self.image = image
+            self.image_matches_host = False
+
         self.name = name
         self.port = port
         self.build = build

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -5,6 +5,8 @@ from typing import Optional
 from config.list import ListConfig
 import docker
 import docker.errors
+import json
+import os
 import sys
 from utils.logger import bm_log, LogType
 from utils.platform import get_os, OperatingSystem
@@ -26,6 +28,7 @@ class ContainersConfig(dict):
         self,
         container_list: Optional[ListConfig] = None,
         core_assignment_policy: CoreAssignPolicy = CoreAssignPolicy(),
+        build: Optional[ListConfig] = None,
         core_affinity_offsets: Optional[ListConfig] = None,
         core_count: int = 1,
         name: str = "",
@@ -54,6 +57,8 @@ class ContainersConfig(dict):
             The base name of the container.
         image: Optional[str] = same as the host OS e.g. ubuntu:latest on Ubuntu.
             The docker image name to use.
+        build: Optional[ListConfig] = list[str]
+            Dockerfile build instructions to build the container.
         port: Optional[int]
             The starting port number to use for the first container.
             Subsequent containers will use incremented port numbers.
@@ -74,6 +79,8 @@ class ContainersConfig(dict):
         self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
         self.name = name
         self.port = port
+        self.build = build
+
         # needs some of the previous fields to be set
         self.__set_cpus_containers(
             core_affinity_offsets=core_affinity_offsets, container_list=container_list
@@ -198,6 +205,69 @@ class ContainersConfig(dict):
         bm_log(f"Execution Unit#{eu_idx} will be assigned CPUS: {cpus_str}")
         return cpus_str
 
+    def __build(self, client):
+        #
+        # Step 1: Create a dockerfile from config.build
+        #
+
+        # A temporary file name
+        dockerfile = "/tmp/.csb_dockerfile"
+
+        # Shall point to the root CSB directory
+        path = os.path.abspath(os.path.dirname(__file__) + "../../..")
+
+        lines = [f"FROM {self.image}"]
+        if self.build:
+            lines += self.build
+
+        with open(dockerfile, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+
+        bm_log(f"Dockerfile written to {dockerfile}")
+
+        #
+        # Step 2: Build a container from a Dockerfile
+        #
+
+        self.image = "csb_build:latest"
+
+        bm_log(f"Building image '{self.image}'")
+
+        try:
+            resp = client.api.build(
+                tag=self.image,
+                dockerfile=dockerfile,
+                path=path,
+                rm=True,
+            )
+            for chunk in resp:
+                chunk_str = chunk.decode("utf-8", errors="ignore")
+                try:
+                    resp_json = json.loads(chunk_str)
+                except json.JSONDecodeError:
+                    bm_log(chunk_str, LogType.INFO)
+                    continue
+
+                for key, value in resp_json.items():
+                    if key in ["stream", ""]:
+                        log_type = LogType.INFO
+                        bm_log(value.rstrip("\n"), LogType.INFO)
+                    elif isinstance(value, dict):
+                        bm_log(f"{key}:", LogType.INFO)
+                        for k, v in value.items():
+                            bm_log(f"  {k}: {v}", LogType.INFO)
+                    else:
+                        bm_log(f"{key}: {value}", LogType.ERROR)
+
+        except docker.errors.BuildError as e:
+            for chunk in e.build_log:
+                if "stream" in chunk:
+                    sys.stdout.write(chunk["stream"])
+            raise
+
+        image = client.images.get(self.image)
+        bm_log(f"Image built: {image.tags}")
+
     def __pull_image(self):
         client = docker.from_env()
         bm_log(f"Docker image {self.image} does not exist. Pulling it now...\n", LogType.INFO)
@@ -209,6 +279,10 @@ class ContainersConfig(dict):
 
     def __ensure_img_exists(self):
         client = docker.from_env()
+
+        if self.build:
+            self.__build(client)
+
         try:
             client.images.get(self.image)
         except docker.errors.ImageNotFound:


### PR DESCRIPTION
Some tests may require setting up a container with extra packages, set different mount volumes and contain more complex logic to build.

Add a "build" key to bm_config, with support to create a Dockerfile and build it.

With that, all it takes to be able to install apps and/or give specific Docker-file instructions is to add a `build` key inside `containers` at the JSON config file. For instance, if one wants to install an external application, all it takes is to add these to the config file:

```patch
     }
   },
   "containers": {
+    "image": "ubuntu:latest",
+    "build": [
+      "RUN apt update && apt install -y fio"
+    ],
     "container_list": {
       "values": [
         {
@@ -56,6 +60,7 @@
   "applications": [
     {
       "name": "fio",
+      "command": "/usr/bin/fio",
       "args": "--name=randrw --filename=/tmp/fio.test --rw=randrw --rwmixread=70 --bs=4k --size={initial_size}G --iodepth=64 --numjobs={threads} --direct=1",
       "adapter": {
         "name": "fio-adapter.sh"
```

This will make it create a docker file like this:

```Dockerfile
FROM ubuntu:latest
RUN apt update && apt install -y fio
```

The entire content of "build" will be placed as-is inside the build Dockerfile, thus allowing any complex scenario that might be required to support external applications.

Please notice that, to suport that, the execution command needs to be placed there and it shall point to the actual location of the exec file, as an absolute path.