### PR TITLE
[bm-runner] Add fallback for when perf is not killed

### DIFF
--- a/bm-runner/bm_container.py
+++ b/bm-runner/bm_container.py
@@ -68,7 +68,7 @@ class Container(ExecutionUnit):
             container.reload()
             if container.status in ("running", "exited", "dead"):
                 break
-
+            # 100 milliseconds
             time.sleep(0.1)
 
     def wait(self, timeout=None):
@@ -87,9 +87,6 @@ class Container(ExecutionUnit):
         bm_log(f"Stopping Container {self.name}")
         try:
             container = self.client.containers.get(self.name)
-
-            self.__log_status(container)
-
             container.stop()
             container.remove()
             # Remove network namespace as well
@@ -99,7 +96,7 @@ class Container(ExecutionUnit):
                     ignore_any_error_code=True,
                     print_file_shell_cmd=False,
                 )
-            bm_log(f"Container: {self.name} has been stopped and removed")
+            self.__log_status(container)
         except docker.errors.NotFound:
             pass  # Container does not exist, nothing to do
 

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -153,6 +153,13 @@ class Executer:
             # wait for all containers to finish
             for eu in self.exec_units:
                 eu.wait()
+        except KeyboardInterrupt:
+            # Warn the user not to pres it again, and shutdown to propagate.
+            bm_log(
+                "User pressed ctrl+c! The benchmark will be interrupted and cleaning up resources will start. Don't press ctrl+c again! Otherwise, you have to clean up containers and monitors manually!",
+                LogType.FATAL,
+            )
+            sys.exit(1)
         finally:
             self.cleanup()
 

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -154,7 +154,7 @@ class Executer:
             for eu in self.exec_units:
                 eu.wait()
         except KeyboardInterrupt:
-            # Warn the user not to pres it again, and shutdown to propagate.
+            # Warn the user not to press it again, and shutdown to propagate.
             bm_log(
                 "User pressed ctrl+c! The benchmark will be interrupted and cleaning up resources will start. Don't press ctrl+c again! Otherwise, you have to clean up containers and monitors manually!",
                 LogType.FATAL,

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -163,9 +163,12 @@ def stop_process(pid: int):
             child.kill()
         parent.kill()
     except psutil.NoSuchProcess:
-        # if a process does not exist we
-        # do not care
         pass
+    except psutil.AccessDenied:
+        bm_log(
+            f"Could not kill process with pid {pid}. Most likely need sudo to kill it.",
+            LogType.ERROR,
+        )
 
 
 def exists_system_wide(cmd: str) -> bool:
@@ -268,3 +271,28 @@ def remove_files_by_ext(dir, extensions: list[str]):
     for extension in extensions:
         for file in folder.rglob(f"*.{extension}"):
             file.unlink()
+
+
+def kill_all(name: str):
+    """
+    Kills all processes with name equals to the given.
+    Use with caution, as this might kill processes that were not created by the framework.
+    """
+    bm_log(f"killing all processes with the name {name}!", LogType.WARNING)
+    shell_out(command=f"sudo pkill {name}", print_file_shell_cmd=False)
+
+
+def is_process_running(name: str) -> bool:
+    """
+    Returns True if it find a running process with the given name.
+    Otherwise, returns False.
+    """
+    for proc in psutil.process_iter(["pid", "name"]):
+        try:
+            # Check if the process name matches the given name
+            if name.lower() in proc.info["name"].lower():
+                bm_log(f"{name} is running {proc.info['pid']}.")
+                return True
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            pass
+    return False

--- a/bm-runner/main.py
+++ b/bm-runner/main.py
@@ -17,6 +17,7 @@ from bm_utils import remove_files_by_ext
 from utils.logger import bm_log, LogType
 from config.env_config import EnvUniversalConfig, UniversalConfig
 from utils.bm_builder import Builder
+from bm_utils import is_process_running, kill_all
 import os
 
 
@@ -122,19 +123,30 @@ if __name__ == "__main__":
         enable_data_dir=True,
     )
 
-    campaign_suite = CampaignSuite(campaigns=[campaign])
-    if not arg_continue:
-        campaign_suite.print_durations()
-        campaign_suite.run_suite()
-        results_dir = campaign.base_data_dir()
-    else:
-        results_dir = dir_arg[0]
-        remove_files_by_ext(results_dir, ["png", "pdf"])
-        bm_log(f"re-visualizing results on {results_dir}, old plots will be removed.", LogType.INFO)
+    try:
+        campaign_suite = CampaignSuite(campaigns=[campaign])
+        if not arg_continue:
+            campaign_suite.print_durations()
+            campaign_suite.run_suite()
+            results_dir = campaign.base_data_dir()
+        else:
+            results_dir = dir_arg[0]
+            remove_files_by_ext(results_dir, ["png", "pdf"])
+            bm_log(
+                f"re-visualizing results on {results_dir}, old plots will be removed.", LogType.INFO
+            )
 
-    # generate an html with the results
-    if results_dir is not None:
-        bm_visualize.visualize_in_html(Path(results_dir), arg_title, bm_config.g_config.get_plots())
-    else:
-        bm_log("results_dir/base_data_dir is None, cannot visualize results.", LogType.FATAL)
-        sys.exit(1)
+        # generate an html with the results
+        if results_dir is not None:
+            bm_visualize.visualize_in_html(
+                Path(results_dir), arg_title, bm_config.g_config.get_plots()
+            )
+        else:
+            bm_log("results_dir/base_data_dir is None, cannot visualize results.", LogType.FATAL)
+            sys.exit(1)
+    finally:
+        # This is only a fallback. Can only happen if the user did ctrl+c twice
+        # interrupting the proper cleanup process.
+        if is_process_running(name="perf"):
+            bm_log("Perf is running and is going to be forcefully killed", LogType.WARNING)
+            kill_all("perf")


### PR DESCRIPTION
Change

- add a fallback for killing perf, when cleanup is interrupted
- warn the user to be patient after the first ctrl+c