### PR TITLE
[bm-runner] Support distant CPUs assignment.

### DIFF
--- a/bm-runner/config/policy.py
+++ b/bm-runner/config/policy.py
@@ -12,11 +12,13 @@ class PackGroup(str, Enum):
     ----------
     PACKAGE: Use CPUs that belong to package/socket zero only.
     NUMA: Use CPUs that belong to NUMA/Node zero only.
+    DISTANT: Use CPUs at the possible maximum distant from each other.
     NO_PACK: CPUs crossing NUMA and package domains can be chosen.
     """
 
     PACKAGE = "package"
     NUMA = "numa"
+    DISTANT = "distant"
     NO_PACK = "none"
 
 

--- a/bm-runner/config/policy.py
+++ b/bm-runner/config/policy.py
@@ -12,7 +12,7 @@ class PackGroup(str, Enum):
     ----------
     PACKAGE: Use CPUs that belong to package/socket zero only.
     NUMA: Use CPUs that belong to NUMA/Node zero only.
-    DISTANT: Use CPUs at the possible maximum distant from each other.
+    DISTANT: [Experimental-feature] Use CPUs at the maximum possible distant from each other.
     NO_PACK: CPUs crossing NUMA and package domains can be chosen.
     """
 
@@ -49,15 +49,17 @@ class CoreAssignPolicy(dict):
         Parameters
         ----------
         pack_group: PackGroup
-            Specifies the policy of CPU selection, whether in the same NUMA, same Package, or
-            can cross packages.
+            Specifies the policy of CPU selection, whether in the same NUMA, same Package,
+            can cross packages, or distant.
         cpu_order: CpuOrder
             Specifies the assignment order, whether ascending to starting for CPU lowest index,
             or descending starting from the highest CPU index.
+            This configuration is ignored if pack_group is distant.
         one_cpu_per_core: bool
             Whether to use only one CPU from each Core. This is relevant to hyper-threading
             when multiple CPUs share the same core. When set to true, from each core only
             the first CPU is considered.
+            This configuration is ignored if pack_group is distant.
         """
         super().__init__(
             pack_group=pack_group, cpu_order=cpu_order, one_cpu_per_core=one_cpu_per_core

--- a/bm-runner/tests/test_topology.py
+++ b/bm-runner/tests/test_topology.py
@@ -171,5 +171,4 @@ def test_distant(mock_read_info):
         distance = cpu_list[1] - cpu_list[0]
         # verify they are at equal distance +-1
         for i in range(1, len(cpu_list)):
-            assert cpu_list[i] - cpu_list[i-1] in (distance-1, distance, distance+1)
-
+            assert cpu_list[i] - cpu_list[i - 1] in (distance - 1, distance, distance + 1)

--- a/bm-runner/tests/test_topology.py
+++ b/bm-runner/tests/test_topology.py
@@ -154,3 +154,22 @@ def test_stats_no_ht(mock_read_info_no_ht):
 def test_lists_no_ht(mock_read_info_no_ht):
     topology = Topology()
     verify_lists(topology)
+
+
+# check distant policy behaves
+# as expected
+def test_distant(mock_read_info):
+    topology = Topology()
+    policy = CoreAssignPolicy(pack_group=PackGroup.DISTANT)
+    cpu_count = topology.get_cpu_count()
+    for count in 2, 40, 7, 310, cpu_count:
+        cpu_list = topology.select(count=count, policy=policy)
+        assert len(cpu_list) == count
+        assert cpu_list[0] == 0
+        assert cpu_list[count - 1] == cpu_count - 1
+        # take the distance between the first two
+        distance = cpu_list[1] - cpu_list[0]
+        # verify they are at equal distance +-1
+        for i in range(1, len(cpu_list)):
+            assert cpu_list[i] - cpu_list[i-1] in (distance-1, distance, distance+1)
+

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -41,7 +41,7 @@ class BackgroundProcess:
         requires: list[str]
             A list of required applications that must be available for the launch to succeed. Each application is checked for existence.
         """
-        assert len(cmds) > 1, "expected at least the process name"
+        assert len(cmds) > 0, "expected at least the process name"
         self.name = name
         self.efile_name = os.path.join(out_dir, f"{self.name}.err")
         if ofile_name is None:

--- a/bm-runner/utils/topology.py
+++ b/bm-runner/utils/topology.py
@@ -146,6 +146,12 @@ class Topology:
 
         return self.__choose(pre_selected, count=count)
 
+    def __distant(self, count:int) -> list[int]:
+        assert count > 1, "Invalid input"
+        cpus = self.get_cpu_count()
+        indices = [round(idx * (cpus-1)/(count -1)) for idx in range(count)]
+        return indices
+
     def select(
         self, count: int, policy: CoreAssignPolicy, pre_selected: Optional[list[int]] = None
     ) -> list[int]:
@@ -184,6 +190,8 @@ class Topology:
                 filter = Filter(self.PACKAGE, 0)
             case PackGroup.NUMA:
                 filter = Filter(self.NUMA, 0)
+            case PackGroup.DISTANT:
+                return self.__distant(count=count)
             case PackGroup.NO_PACK:
                 filter = None
             case _:

--- a/bm-runner/utils/topology.py
+++ b/bm-runner/utils/topology.py
@@ -146,10 +146,10 @@ class Topology:
 
         return self.__choose(pre_selected, count=count)
 
-    def __distant(self, count:int) -> list[int]:
+    def __distant(self, count: int) -> list[int]:
         assert count > 1, "Invalid input"
         cpus = self.get_cpu_count()
-        indices = [round(idx * (cpus-1)/(count -1)) for idx in range(count)]
+        indices = [round(idx * (cpus - 1) / (count - 1)) for idx in range(count)]
         return indices
 
     def select(
@@ -191,7 +191,13 @@ class Topology:
             case PackGroup.NUMA:
                 filter = Filter(self.NUMA, 0)
             case PackGroup.DISTANT:
-                return self.__distant(count=count)
+                # distant policy only makes sense if the
+                # requested number of CPUs is greater than 1
+                # and less than the total number of CPUs
+                if count > 1 and count < self.get_cpu_count():
+                    return self.__distant(count=count)
+                # fallback on normal selection way
+                filter = None
             case PackGroup.NO_PACK:
                 filter = None
             case _:

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -110,9 +110,9 @@ Adapters used to transform the output of an external benchmark into the format u
 CPU/Core assignment policy for execution units, i.e. containers and native processes.  
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`none`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package, or     can cross packages. |
-|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`asc`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index. |
-|one_cpu_per_core|bool|:white_check_mark:|`False`|    Whether to use only one CPU from each Core. This is relevant to hyper-threading     when multiple CPUs share the same core. When set to true, from each core only |
+|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`none`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
+|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`asc`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
+|one_cpu_per_core|bool|:white_check_mark:|`False`|    Whether to use only one CPU from each Core. This is relevant to hyper-threading     when multiple CPUs share the same core. When set to true, from each core only     the first CPU is considered. |
 ## MonitorType
 Monitors are used to monitor performance. They can be used to analyze the behavior of the benchmarks.  <br/>Supported values:
 - `"mpstat"`:  Runs mpstat and generates related graphs.
@@ -144,6 +144,7 @@ Supported CPU orders.  <br/>Supported values:
 Supported groups for packing.  <br/>Supported values:
 - `"package"`:  Use CPUs that belong to package/socket zero only.
 - `"numa"`:  Use CPUs that belong to NUMA/Node zero only.
+- `"distant"`:  [Experimental-feature] Use CPUs at the maximum possible distant from each other.
 - `"none"`:  CPUs crossing NUMA and package domains can be chosen.
 ## Environment Variables
 CSB bm-runner has universal configuration that can overwrite default behavior and JSON config values. These are set via environment variables, and are read at runtime.  <br/>Supported values:


### PR DESCRIPTION
Change

- add a new `distant` option to policy, to choose
  CPUs as far as possible away from each other.

Fix

- assertion in `process.py`
