### PR TITLE
[bm-runner] Add config to allow for pinning monitors.

### DIFF
--- a/bm-runner/config/env_config.py
+++ b/bm-runner/config/env_config.py
@@ -16,6 +16,7 @@ class UniversalConfig(str, Enum):
     ----------
     CSB_NO_CLEAN_BENCH: When set to `true`, it disables the cleaning of the build folder of builtin benchmarks.
     CSB_ANALYZE: When set to `false`, it disables the analysis monitors.
+    CSB_PIN_MONITORS: When set to `true`, all monitors will be pinned to a specific CPU.
     CSB_NO_BUILD_BENCH: when set to `true`, it skips building *all* builtin benchmarks.
     CSB_RESULTS_GROUP: when set to <dir-name>, bm-runner dumps all results under results/<dir-name>.
     """
@@ -23,13 +24,14 @@ class UniversalConfig(str, Enum):
     CSB_NO_CLEAN_BENCH = "CSB_NO_CLEAN_BENCH"
     CSB_ANALYZE = "CSB_ANALYZE"
     CSB_NO_BUILD_BENCH = "CSB_NO_BUILD_BENCH"
+    CSB_PIN_MONITORS = "CSB_PIN_MONITORS"
     CSB_RESULTS_GROUP = "CSB_RESULTS_GROUP"
-
 
 class EnvUniversalConfig:
     DEFAULT_ENV_CONFIG: dict[UniversalConfig, bool] = {
         UniversalConfig.CSB_NO_CLEAN_BENCH: False,
         UniversalConfig.CSB_NO_BUILD_BENCH: False,
+        UniversalConfig.CSB_PIN_MONITORS: False,
         UniversalConfig.CSB_ANALYZE: True,
     }
     TRUE_VALS: set[str] = {"true", "1", "yes", "on"}

--- a/bm-runner/config/env_config.py
+++ b/bm-runner/config/env_config.py
@@ -27,6 +27,7 @@ class UniversalConfig(str, Enum):
     CSB_PIN_MONITORS = "CSB_PIN_MONITORS"
     CSB_RESULTS_GROUP = "CSB_RESULTS_GROUP"
 
+
 class EnvUniversalConfig:
     DEFAULT_ENV_CONFIG: dict[UniversalConfig, bool] = {
         UniversalConfig.CSB_NO_CLEAN_BENCH: False,

--- a/bm-runner/monitors/monitor.py
+++ b/bm-runner/monitors/monitor.py
@@ -3,9 +3,9 @@
 
 from abc import abstractmethod
 from typing import Optional
-from config.env_config import EnvUniversalConfig,UniversalConfig
-from utils.logger import bm_log, LogType
+from config.env_config import EnvUniversalConfig, UniversalConfig
 import os
+
 
 class Monitor:
     def __init__(self, dir, args):
@@ -14,9 +14,10 @@ class Monitor:
 
     def get_cpus(self) -> Optional[list[int]]:
         if EnvUniversalConfig.is_on(UniversalConfig.CSB_PIN_MONITORS):
-            return [os.cpu_count() - 1]
-        else:
-            None
+            cpu_count = os.cpu_count()
+            if cpu_count is not None:
+                return [cpu_count - 1]
+        return None
 
     @abstractmethod
     def stop(self):

--- a/bm-runner/monitors/monitor.py
+++ b/bm-runner/monitors/monitor.py
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: MIT
 
 from abc import abstractmethod
-
+from typing import Optional
+import os
 
 class Monitor:
     def __init__(self, dir, args):
         self.dir = dir
         self.args = args
+
+    def get_cpus(self) -> Optional[list[int]]:
+        return [os.cpu_count() - 1]
 
     @abstractmethod
     def stop(self):

--- a/bm-runner/monitors/monitor.py
+++ b/bm-runner/monitors/monitor.py
@@ -3,6 +3,8 @@
 
 from abc import abstractmethod
 from typing import Optional
+from config.env_config import EnvUniversalConfig,UniversalConfig
+from utils.logger import bm_log, LogType
 import os
 
 class Monitor:
@@ -11,7 +13,10 @@ class Monitor:
         self.args = args
 
     def get_cpus(self) -> Optional[list[int]]:
-        return [os.cpu_count() - 1]
+        if EnvUniversalConfig.is_on(UniversalConfig.CSB_PIN_MONITORS):
+            return [os.cpu_count() - 1]
+        else:
+            None
 
     @abstractmethod
     def stop(self):

--- a/bm-runner/monitors/mpstat.py
+++ b/bm-runner/monitors/mpstat.py
@@ -26,7 +26,7 @@ class SystemStats(Monitor):
             cmds=cmds,
             out_dir=output_dir,
             requires=["mpstat"],
-            pin = self.get_cpus(),
+            pin=self.get_cpus(),
         )
 
     def start(self):

--- a/bm-runner/monitors/mpstat.py
+++ b/bm-runner/monitors/mpstat.py
@@ -26,6 +26,7 @@ class SystemStats(Monitor):
             cmds=cmds,
             out_dir=output_dir,
             requires=["mpstat"],
+            pin = self.get_cpus(),
         )
 
     def start(self):

--- a/bm-runner/monitors/perf.py
+++ b/bm-runner/monitors/perf.py
@@ -16,7 +16,9 @@ class FlameGraph(Monitor):
         super().__init__(dir=output_dir, args=args)
         cmds = ["sudo", "perf", "record", "-F", "99", "-g"]
         cmds.extend(args)
-        self.perf = BackgroundProcess(name="perf", out_dir=output_dir, cmds=cmds, requires=["perf"], pin = self.get_cpus())
+        self.perf = BackgroundProcess(
+            name="perf", out_dir=output_dir, cmds=cmds, requires=["perf"], pin=self.get_cpus()
+        )
         self.fg_path = os.getenv(self.FG_PATH_ENV_VAR_NAME)
         if self.fg_path is None:
             bm_log(

--- a/bm-runner/monitors/perf.py
+++ b/bm-runner/monitors/perf.py
@@ -16,7 +16,7 @@ class FlameGraph(Monitor):
         super().__init__(dir=output_dir, args=args)
         cmds = ["sudo", "perf", "record", "-F", "99", "-g"]
         cmds.extend(args)
-        self.perf = BackgroundProcess(name="perf", out_dir=output_dir, cmds=cmds, requires=["perf"])
+        self.perf = BackgroundProcess(name="perf", out_dir=output_dir, cmds=cmds, requires=["perf"], pin = self.get_cpus())
         self.fg_path = os.getenv(self.FG_PATH_ENV_VAR_NAME)
         if self.fg_path is None:
             bm_log(

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -60,7 +60,7 @@ class BackgroundProcess:
             self.cmds = cmds
         else:
             cpus = ",".join([str(c) for c in pin])
-            cmd_prefix=["taskset", "--cpu-list", cpus]
+            cmd_prefix = ["taskset", "--cpu-list", cpus]
             self.cmds = cmd_prefix + cmds
 
         # ensure process exist

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -21,6 +21,7 @@ class BackgroundProcess:
         cmds: list[str],
         wdir: Optional[str] = None,
         ofile_name: Optional[str] = None,
+        pin: Optional[list[int]] = None,
         requires: list[str] = [],
     ):
         """
@@ -38,6 +39,9 @@ class BackgroundProcess:
             The working directory where the process will be executed. If not provided, `out_dir` will be used as the working directory.
         ofile_name: Optional[str]
             The name of the file to save `stdout` to. If not provided, a given `name` with a `.log` extension will be used.
+        pin: Optional[list[int]]
+            Optional list of CPUs to assign to the process with taskset.
+            If None, the process will not be assigned specific CPUs.
         requires: list[str]
             A list of required applications that must be available for the launch to succeed. Each application is checked for existence.
         """
@@ -48,11 +52,17 @@ class BackgroundProcess:
             self.ofile_name = os.path.join(out_dir, f"{self.name}.log")
         else:
             self.ofile_name = os.path.join(out_dir, ofile_name)
-        self.cmds = cmds
         self.wdir = out_dir if wdir is None else wdir
         self.process: Optional[subprocess.Popen] = None
         self.ofile = None
         self.efile = None
+        if pin is None:
+            self.cmds = cmds
+        else:
+            cpus = ",".join([str(c) for c in pin])
+            cmd_prefix=["taskset", "--cpu-list", cpus]
+            self.cmds = cmd_prefix + cmds
+
         # ensure process exist
         for tool in requires:
             ensure_exists(tool)

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -151,4 +151,5 @@ CSB bm-runner has universal configuration that can overwrite default behavior an
 - `"CSB_NO_CLEAN_BENCH"`:  When set to `true`, it disables the cleaning of the build folder of builtin benchmarks.
 - `"CSB_ANALYZE"`:  When set to `false`, it disables the analysis monitors.
 - `"CSB_NO_BUILD_BENCH"`:  when set to `true`, it skips building *all* builtin benchmarks.
+- `"CSB_PIN_MONITORS"`:  When set to `true`, all monitors will be pinned to a specific CPU.
 - `"CSB_RESULTS_GROUP"`:  when set to <dir-name>, bm-runner dumps all results under results/<dir-name>.


### PR DESCRIPTION
Change

- add env-var config `CSB_PIN_MONITORS` when set
  to true, monitors are pinned to the last CPU
- respect pinning config in `mpstat` and `perf`