### PR TITLE
[bm-runner] Increase the open file limit

### DIFF
--- a/scripts/fg-diff/run-single.sh
+++ b/scripts/fg-diff/run-single.sh
@@ -40,7 +40,9 @@ cd ${BM_DIR}
 
 info "running $TITLE on $CONFIG"
 
+FD_LIMIT=$(ulimit -H -n)
+info "Setting the open files limit to $FD_LIMIT"
 # set file limit to the max
-ulimit -n $(ulimit -H -n)
+ulimit -n $FD_LIMIT
 
 python3 main.py --title "$TITLE" --config "$CONFIG" $*

--- a/scripts/fg-diff/run-single.sh
+++ b/scripts/fg-diff/run-single.sh
@@ -40,4 +40,7 @@ cd ${BM_DIR}
 
 info "running $TITLE on $CONFIG"
 
+# set file limit to the max
+ulimit -n $(ulimit -H -n)
+
 python3 main.py --title "$TITLE" --config "$CONFIG" $*


### PR DESCRIPTION
Change

- set the open files limit to hard limit
  before running the benchmark