### PR TITLE
scripts/run-all.sh: better handle arguments

### DIFF
--- a/scripts/run-all.sh
+++ b/scripts/run-all.sh
@@ -6,7 +6,8 @@ set -e
 
 # examples:
 #   scripts/run-all.sh # runs everything under config
-#   scripts/run-all.sh *sql* # runs all with config matching *sql*
+#   scripts/run-all.sh "*sql*" # runs all with config matching *sql*
+#   scripts/run-all.sh "*sql*" bm_empty # run configs matching *sql* plus bm_empty
 
 # Configure the venv
 if [ ! -d venv ]; then
@@ -15,19 +16,38 @@ fi
 
 . ./venv/bin/activate
 
+shopt -s globstar
+shopt -s nullglob
+
+BENCHMARKS_CONFIGS=()
+
 if [ $# -eq 0 ]; then
-    REGEX="*"
+    BENCHMARKS_CONFIGS+=(config/**/*.json)
 else
-    REGEX="$1"
+    for pattern in "$@"; do
+        pattern="${pattern#config/}"
+        pattern="${pattern%.json}"
+        BENCHMARKS_CONFIGS+=( config/**/${pattern}.json )
+    done
 fi
 
-shopt -s globstar
-BENCHMARKS_CONFIGS=( config/**/$REGEX.json )
+ntests=${#BENCHMARKS_CONFIGS[@]}
+
+if [ ${ntests} -eq 0 ];then
+    echo "No tests to run."
+   exit 1
+fi
 
 echo "We require sudo to run the benchmarks"
 sudo -v  # This will prompt for the sudo password and keep it cached
 
+n=1
 for CONFIG in ${BENCHMARKS_CONFIGS[@]}; do
-    echo "Running: $CONFIG"
+    echo
+    echo "======================================================================================="
+    echo "${n}/${ntests} running: $CONFIG"
+    echo "======================================================================================="
+    echo
     scripts/run-single.sh "$CONFIG"
+    n=$((n + 1))
 done


### PR DESCRIPTION
There are several issues at the way it currently handle args:
- only one argument is accepted;
- logic fails if name is prepended with config or ends with .json;
- even when there's no match, it asks for a sudo password.

Address them.

While here, add a way to know what test number is currently running and how many are expected to run.