### PR TITLE
bm-runner: Allow runner to automatically set CPU counts.

### DIFF
--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -37,6 +37,8 @@ class ContainersConfig(dict):
         ----------
         container_list: ListConfig = {"values": [[1]]}
             Specifies the number of containers to run.
+            If container_list is present, but empty, a list will be
+            auto-generated.
         one_cpu_per_core: bool = False,
         core_assignment_policy: CoreAssignPolicy = {"pack_group":"none", "cpu_order": "asc", "one_cpu_per_core": false}
             Configures the CPU assignment policy, i.e. which CPUs can be assigned to execution units (containers/native processes).
@@ -68,9 +70,11 @@ class ContainersConfig(dict):
         self.cpus: list[int]
         self.policy: CoreAssignPolicy
         self.topo = Topology()
-        self.container_list = ListConfig.from_dict(container_list).get_list()
+        self.container_list = ListConfig.from_dict(container_list).get_list(core_count)
         self.core_count = core_count
-        self.__set_cpus(policy=core_assignment_policy, core_affinity_offsets=core_affinity_offsets)
+        self.__set_cpus(
+            policy=core_assignment_policy, core_affinity_offsets=core_affinity_offsets
+        )
         self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
         self.name = name
         self.port = port
@@ -84,7 +88,7 @@ class ContainersConfig(dict):
         pre_selected_cpus: Optional[list[int]] = (
             None
             if core_affinity_offsets is None
-            else ListConfig.from_dict(core_affinity_offsets).get_list()
+            else ListConfig.from_dict(core_affinity_offsets).get_list(self.core_count)
         )
         self.policy = CoreAssignPolicy.from_dict(policy)
         # Calculate the maximum number of CPUs needed.
@@ -120,11 +124,16 @@ class ContainersConfig(dict):
 
     def __pull_image(self):
         client = docker.from_env()
-        bm_log(f"Docker image {self.image} does not exist. Pulling it now...\n", LogType.INFO)
+        bm_log(
+            f"Docker image {self.image} does not exist. Pulling it now...\n",
+            LogType.INFO,
+        )
         try:
             client.images.pull(self.image)
         except Exception as e:
-            bm_log(f"Failed to pull image {self.image} with error {str(e)}", LogType.FATAL)
+            bm_log(
+                f"Failed to pull image {self.image} with error {str(e)}", LogType.FATAL
+            )
             sys.exit(1)
 
     def __ensure_img_exists(self):

--- a/bm-runner/config/list.py
+++ b/bm-runner/config/list.py
@@ -1,6 +1,8 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+import os
+
 from typing import Optional
 from typing import Union
 from utils.logger import bm_log, LogType
@@ -38,15 +40,18 @@ class RangeConfig(dict):
 
 class ListConfig(dict):
     def __init__(
-        self, values: list[Union[list[int], RangeConfig]], str_format: Optional[str] = None
+        self,
+        values: Optional[list[Union[list[int], RangeConfig]]],
+        str_format: Optional[str] = None,
     ):
         """
         Parameters
         ----------
-        values: list[Union[list[int], RangeConfig]]
-            list of values each value an be either a list of integers, or `RangeConfig`
+        values: Optional[list[Union[list[int], RangeConfig]]]
+            list of values each value an be either a list of integers or a `RangeConfig`
             object.
-            JSON example `"values": [ [5, 6], {"min": 1, "step": 1, "max": 3 }, [12] ]}`
+            If not specified, it will automatically fill based on the number of CPUs.
+            JSON example: `"values": [ [5, 6], {"min": 1, "step": 1, "max": 3 }, [12] ]`
         str_format: Optional[str]
             A formatting string. Used to convert the values into string.
             JSON example: `"str_format": "127.0.0.{i}"`
@@ -61,18 +66,50 @@ class ListConfig(dict):
 
     @classmethod
     def from_dict(cls, data: dict):
-        return cls(data["values"], data.get("str_format"))
+        return cls(data.get("values"), data.get("str_format"))
 
-    def get_list(self):
+    def get_list(self, core_count: int = 1):
         combined_lists = []
-        for cfg in self.vals:
-            if isinstance(cfg, list):
-                combined_lists.extend(cfg)
-            elif isinstance(cfg, dict):
-                range = RangeConfig.from_dict(cfg)
-                combined_lists.extend(range.get_list())
-            else:
-                bm_log(f"I cannot handle {type(cfg)}, skipping this item", LogType.ERROR)
+
+        if not self.vals:
+            cpu_count = os.cpu_count()
+            if not cpu_count:
+                cpu_count = 1
+
+            max_cpus = max(1, int(cpu_count / core_count))
+            step = None
+
+            if max_cpus > 8 and max_cpus % 8 == 0:
+                step = 8
+
+            if not step:
+                step = max_cpus
+
+            while (step > 1) and (max_cpus / step) < 4:
+                step = int(step / 2)
+
+            while (max_cpus / step) > 8:
+                step *= 2
+
+            for cpu in range(step, max_cpus + 1, step):
+                combined_lists.append(cpu)
+
+            combined_lists.append(1)
+            combined_lists.append(max_cpus)
+
+        else:
+            for cfg in self.vals:
+
+                if isinstance(cfg, list):
+                    combined_lists.extend(cfg)
+                elif isinstance(cfg, dict):
+                    rangecfg = RangeConfig.from_dict(cfg)
+                    combined_lists.extend(rangecfg.get_list())
+                else:
+                    bm_log(
+                        f"I cannot handle {type(cfg)}, skipping this item",
+                        LogType.ERROR,
+                    )
 
         # make sure there are no duplicated items
         unique_list = sorted(set(combined_lists))

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -25,25 +25,11 @@
     "noise": [
       10
     ],
-    "threads": {
-      "values": [
-        [
-          2
-        ]
-      ]
-    },
+    "threads": {},
     "duration": 1
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1,
-          5,
-          10
-        ]
-      ]
-    },
+    "container_list": {},
     "core_count": 3,
     "core_assignment_policy": {
       "cpu_order": "desc",

--- a/config/bm_server_redis.json
+++ b/config/bm_server_redis.json
@@ -95,15 +95,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1,
-          5,
-          10
-        ]
-      ]
-    },
+    "container_list": {},
     "name": "redis-like",
     "port": 8000
   },

--- a/config/byte-unixbench.json
+++ b/config/byte-unixbench.json
@@ -22,26 +22,10 @@
     }
   ],
   "benchmark_config": {
-    "threads": {
-      "values": [
-        [
-          1
-        ]
-      ]
-    }
+    "threads": {}
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1,
-          2,
-          4,
-          6,
-          8
-        ]
-      ]
-    },
+    "container_list": {},
     "core_count": 2
   },
   "applications": [

--- a/config/fio.json
+++ b/config/fio.json
@@ -32,25 +32,10 @@
         "0,1"
       ]
     },
-    "threads": {
-      "values": [
-        [
-          1,
-          3
-        ]
-      ]
-    }
+    "threads": {}
   },
   "containers": {
-    "container_list": {
-      "values": [
-        {
-          "min": 1,
-          "step": 1,
-          "max": 3
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 3
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_faccessat2_missing_1_0.json
+++ b/config/mysql/bm_min_mysql_faccessat2_missing_1_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_fcntl_setsockopt_0_0.json
+++ b/config/mysql/bm_min_mysql_fcntl_setsockopt_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_fsync_fcntl_3_0.json
+++ b/config/mysql/bm_min_mysql_fsync_fcntl_3_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_fsync_fcntl_7_0.json
+++ b/config/mysql/bm_min_mysql_fsync_fcntl_7_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_fsync_pwrite64_0_0.json
+++ b/config/mysql/bm_min_mysql_fsync_pwrite64_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_101_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_101_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_104_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_104_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_109_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_109_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_24_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_24_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_44_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_44_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_45_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_45_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_66_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_66_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_68_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_68_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_79_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_79_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_81_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_81_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_94_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_94_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_97_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_97_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_98_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_98_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fallocate_99_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fallocate_99_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fcntl_17_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fcntl_17_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fcntl_20_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fcntl_20_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fcntl_21_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fcntl_21_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_fcntl_23_0.json
+++ b/config/mysql/bm_min_mysql_lseek_fcntl_23_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_openat_0_0.json
+++ b/config/mysql/bm_min_mysql_lseek_openat_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_pwrite64_0_0.json
+++ b/config/mysql/bm_min_mysql_lseek_pwrite64_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_pwrite64_24_0.json
+++ b/config/mysql/bm_min_mysql_lseek_pwrite64_24_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_lseek_pwrite64_9_0.json
+++ b/config/mysql/bm_min_mysql_lseek_pwrite64_9_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_newfstatat_getdents64_0_0.json
+++ b/config/mysql/bm_min_mysql_newfstatat_getdents64_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_newfstatat_missing_0_0.json
+++ b/config/mysql/bm_min_mysql_newfstatat_missing_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_newfstatat_openat_0_0.json
+++ b/config/mysql/bm_min_mysql_newfstatat_openat_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_openat_lseek_26_0.json
+++ b/config/mysql/bm_min_mysql_openat_lseek_26_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_pread64_fcntl_8_0.json
+++ b/config/mysql/bm_min_mysql_pread64_fcntl_8_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_pread64_lseek_0_0.json
+++ b/config/mysql/bm_min_mysql_pread64_lseek_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_pread64_write_29_0.json
+++ b/config/mysql/bm_min_mysql_pread64_write_29_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_pwrite64_fcntl_0_0.json
+++ b/config/mysql/bm_min_mysql_pwrite64_fcntl_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_pwrite64_lseek_3_0.json
+++ b/config/mysql/bm_min_mysql_pwrite64_lseek_3_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_pwrite64_openat_0_0.json
+++ b/config/mysql/bm_min_mysql_pwrite64_openat_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_read_openat_1_0.json
+++ b/config/mysql/bm_min_mysql_read_openat_1_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_read_write_0_0.json
+++ b/config/mysql/bm_min_mysql_read_write_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_readlinkat_missing_14_0.json
+++ b/config/mysql/bm_min_mysql_readlinkat_missing_14_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_readlinkat_missing_63_0.json
+++ b/config/mysql/bm_min_mysql_readlinkat_missing_63_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_readlinkat_newfstatat_0_0.json
+++ b/config/mysql/bm_min_mysql_readlinkat_newfstatat_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/mysql/bm_min_mysql_recvfrom_sendto_0_0.json
+++ b/config/mysql/bm_min_mysql_recvfrom_sendto_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "port": 8000,
     "core_count": 1
   },

--- a/config/mysql/bm_min_mysql_recvfrom_sendto_20_0.json
+++ b/config/mysql/bm_min_mysql_recvfrom_sendto_20_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "port": 8000,
     "core_count": 1
   },

--- a/config/mysql/bm_min_mysql_recvfrom_sendto_32_0.json
+++ b/config/mysql/bm_min_mysql_recvfrom_sendto_32_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "port": 8000,
     "core_count": 1
   },

--- a/config/rocksdb/bm_min_rocks_fcntl_pread64_0_0.json
+++ b/config/rocksdb/bm_min_rocks_fcntl_pread64_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_fcntl_read_0_0.json
+++ b/config/rocksdb/bm_min_rocks_fcntl_read_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_newfstatat_missing_0_0.json
+++ b/config/rocksdb/bm_min_rocks_newfstatat_missing_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_pread64_fcntl_67_0.json
+++ b/config/rocksdb/bm_min_rocks_pread64_fcntl_67_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_pread64_write_0_0.json
+++ b/config/rocksdb/bm_min_rocks_pread64_write_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_read_fcntl_0_0.json
+++ b/config/rocksdb/bm_min_rocks_read_fcntl_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_read_openat_0_0.json
+++ b/config/rocksdb/bm_min_rocks_read_openat_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_read_openat_2_0.json
+++ b/config/rocksdb/bm_min_rocks_read_openat_2_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_write_fcntl_0_0.json
+++ b/config/rocksdb/bm_min_rocks_write_fcntl_0_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_write_fcntl_5_0.json
+++ b/config/rocksdb/bm_min_rocks_write_fcntl_5_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_write_fcntl_7_0.json
+++ b/config/rocksdb/bm_min_rocks_write_fcntl_7_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_write_fcntl_8_0.json
+++ b/config/rocksdb/bm_min_rocks_write_fcntl_8_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/rocksdb/bm_min_rocks_write_fcntl_9_0.json
+++ b/config/rocksdb/bm_min_rocks_write_fcntl_9_0.json
@@ -49,18 +49,7 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1
-        ],
-        {
-          "min": 5,
-          "step": 5,
-          "max": 30
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 1
   },
   "applications": [

--- a/config/stress-ng.json
+++ b/config/stress-ng.json
@@ -40,25 +40,10 @@
         "0,1"
       ]
     },
-    "threads": {
-      "values": [
-        [
-          1,
-          3
-        ]
-      ]
-    }
+    "threads": {}
   },
   "containers": {
-    "container_list": {
-      "values": [
-        {
-          "min": 1,
-          "step": 1,
-          "max": 3
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 3
   },
   "applications": [

--- a/config/will-it-scale.json
+++ b/config/will-it-scale.json
@@ -32,23 +32,9 @@
     "value": "desc",
     "type": "str"
   },
-  "threads": {
-    "values": [
-      [
-        1
-      ]
-    ]
-  },
+  "threads": {},
   "containers": {
-    "container_list": {
-      "values": [
-        {
-          "min": 1,
-          "step": 1,
-          "max": 3
-        }
-      ]
-    },
+    "container_list": {},
     "core_count": 3
   },
   "applications": [

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -39,7 +39,7 @@ ContainersConfig represents the configuration for multiple containers. Represent
 <br/>***JSON key: "containers"***
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|container_list|[ListConfig](#listconfig)|:white_check_mark:|`{"values": [[1]]}`|    Specifies the number of containers to run. |
+|container_list|[ListConfig](#listconfig)|:white_check_mark:|`{"values": [[1]]}`|    Specifies the number of containers to run.     If container_list is present, but empty, a list will be     auto-generated. |
 |core_assignment_policy|[CoreAssignPolicy](#coreassignpolicy)|:white_check_mark:|`{"pack_group":"none", "cpu_order": "asc", "one_cpu_per_core": false}`|    Configures the CPU assignment policy, i.e. which CPUs can be assigned to execution units (containers/native processes).     Note that the policy is overwritten by `core_affinity_offsets`. If the users wish to use this configuration, they     should make sure not to specify `core_affinity_offsets`. |
 |core_affinity_offsets|[ListConfig](#listconfig)|:white_check_mark:|`core_count * [0, 1, 2, 3, ...]`|    Specifies the cores that should be assigned to the containers.     Note that the assignment of cores happens in ascending order by default.     This configuration overwrites `core_assignment_policy`. |
 |core_count|int|:white_check_mark:|`1`|    Number of cores to assign to each container. |
@@ -71,7 +71,7 @@ Plot configuration for benchmark results. Represented as a JSON array of objects
 |hue_lbl|str|:white_check_mark:|`{hue}`|    The label for the hue/groupby. If None, defaults to `{hue}`. |
 |title|str|:white_check_mark:|`{x_lbl} vs. {y_lbl}`|    The title of the plot. If None, defaults to `{x_lbl} vs. {y_lbl}`. |
 |shape|str|:white_check_mark:||    The shape/type of the plot (e.g., 'lineplot', 'barplot'). If None, defaults based on `type`. |
-|type|[PlotType](#plottype)|:white_check_mark:|`normal`|    The type of plot to be created, which determines default shape and other behaviors. |
+|type|[PlotType](#plottype)|:white_check_mark:|`PlotType.NORMAL`|    The type of plot to be created, which determines default shape and other behaviors. |
 
 ## NicsConfig
 NicsConfig configures the assignment of Network Interface Cards (NICs) or their Virtual Functions (VFs) to containers. Represented as a JSON object. 
@@ -95,7 +95,7 @@ Adapters used to transform the output of an external benchmark into the format u
 
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|values|list[Union[list[int], [RangeConfig](#rangeconfig)]]|:x:||    list of values each value an be either a list of integers, or `RangeConfig`     object.     JSON example `"values": [ [5, 6], {"min": 1, "step": 1, "max": 3 }, [12] ]}` |
+|values|list[Union[list[int], [RangeConfig](#rangeconfig)]]|:x:||    list of values each value an be either a list of integers or a `RangeConfig`     object.     If not specified, it will automatically fill based on the number of CPUs.     JSON example: `"values": [ [5, 6], {"min": 1, "step": 1, "max": 3 }, [12] ]` |
 |str_format|str|:white_check_mark:||    A formatting string. Used to convert the values into string.     JSON example: `"str_format": "127.0.0.{i}"`     with this string the values `i` is replaced by an integer from values     and the list become:     `["127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.5", "127.0.0.6", "127.0.0.12"]` |
 
 ## RangeConfig
@@ -110,8 +110,8 @@ Adapters used to transform the output of an external benchmark into the format u
 CPU/Core assignment policy for execution units, i.e. containers and native processes.  
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`none`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
-|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`asc`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
+|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`PackGroup.NO_PACK`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
+|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`CpuOrder.ASC`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
 |one_cpu_per_core|bool|:white_check_mark:|`False`|    Whether to use only one CPU from each Core. This is relevant to hyper-threading     when multiple CPUs share the same core. When set to true, from each core only     the first CPU is considered. |
 ## MonitorType
 Monitors are used to monitor performance. They can be used to analyze the behavior of the benchmarks.  <br/>Supported values:


### PR DESCRIPTION
When the same benchmark test is intended to be executed on  different
 machines with a different number of CPUs (or with  SMT 
disabled/enabled), it is desired to automatically adjust  the CPU count to 
better fit at the machine's specs.

Add support for it by letting CSB to automatically fill container list based on
 os.cpu_count() and cpu_count.

Change most of the tests to use auto-generated limits.
