### PR TITLE
[bm-runner] Dynamically set default `container_list` config.

### DIFF
--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -271,29 +271,3 @@ def is_process_running(name: str) -> bool:
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             pass
     return False
-
-
-def closest_divisor_10_percent(N):
-    target = N * 0.1  # 10% of N
-    closest_divisor = 1
-    min_diff = N  # Start with a big difference
-
-    # Only need to check divisors up to sqrt(N)
-    for i in range(1, int(N**0.5) + 1):
-        if N % i == 0:
-            # i is a divisor
-            j = N // i  # paired divisor
-
-            # Check i
-            diff_i = abs(i - target)
-            if diff_i < min_diff:
-                min_diff = diff_i
-                closest_divisor = i
-
-            # Check paired divisor j
-            diff_j = abs(j - target)
-            if diff_j < min_diff:
-                min_diff = diff_j
-                closest_divisor = j
-
-    return closest_divisor

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -271,3 +271,29 @@ def is_process_running(name: str) -> bool:
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             pass
     return False
+
+
+def closest_divisor_10_percent(N):
+    target = N * 0.1  # 10% of N
+    closest_divisor = 1
+    min_diff = N  # Start with a big difference
+
+    # Only need to check divisors up to sqrt(N)
+    for i in range(1, int(N**0.5) + 1):
+        if N % i == 0:
+            # i is a divisor
+            j = N // i  # paired divisor
+
+            # Check i
+            diff_i = abs(i - target)
+            if diff_i < min_diff:
+                min_diff = diff_i
+                closest_divisor = i
+
+            # Check paired divisor j
+            diff_j = abs(j - target)
+            if diff_j < min_diff:
+                min_diff = diff_j
+                closest_divisor = j
+
+    return closest_divisor

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -93,7 +93,7 @@ class ContainersConfig(dict):
             count=max_cpu_count, policy=self.policy, pre_selected=pre_selected_cpus
         )
 
-    def __get_gen_list(self, max, cpus_per_container) -> list[int]:
+    def __gen_container_list(self, max, cpus_per_container) -> list[int]:
         num_steps = 16
         if max < num_steps:
             step = 1
@@ -118,10 +118,7 @@ class ContainersConfig(dict):
         else:
             # if hyper-threads are allowed we define it based on the CPU count
             max  = math.floor(self.topo.get_cpu_count() / cpus_per_container)
-
-            return self.__get_gen_list(max=max, cpus_per_container=cpus_per_container)
-
-
+        return self.__gen_container_list(max=max, cpus_per_container=cpus_per_container)
 
     def get_container_cnt_list(self) -> list[int]:
         return self.container_list

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -105,12 +105,14 @@ class ContainersConfig(dict):
             """
             )
             self.container_list = self.__gen_container_list(max_num_containers)
+            # do not multiply by core count here, because that is already factored in
+            max_cpu_count = max(self.container_list)
         else:
             self.container_list = ListConfig.from_dict(container_list).get_list()
+            # Calculate the maximum number of CPUs needed.
+            # max number of containers * cores per container
+            max_cpu_count = max(self.container_list) * self.core_count
 
-        # Calculate the maximum number of CPUs needed.
-        # max number of containers * cores per container
-        max_cpu_count = max(self.container_list) * self.core_count
         self.cpus = self.topo.select(
             count=max_cpu_count, policy=self.policy, pre_selected=pre_selected_cpus
         )

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -70,27 +70,37 @@ class ContainersConfig(dict):
         self.topo = Topology()
         self.core_count = core_count
         self.policy = CoreAssignPolicy.from_dict(core_assignment_policy)
-        self.container_list = (
-            self.__get_default_container_list()
-            if container_list is None
-            else ListConfig.from_dict(container_list).get_list()
-        )
-        self.__set_cpus(core_affinity_offsets=core_affinity_offsets)
         self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
         self.name = name
         self.port = port
+        # needs some of the previous fields to be set
+        self.__set_cpus_containers(core_affinity_offsets=core_affinity_offsets, container_list=container_list)
         self.__ensure_img_exists()
 
-    def __set_cpus(self, core_affinity_offsets):
-        """
-        Selects which CPUs are allowed to be used according to the
-        policy and core_affinity_offsets.
-        """
-        pre_selected_cpus: Optional[list[int]] = (
-            None
-            if core_affinity_offsets is None
-            else ListConfig.from_dict(core_affinity_offsets).get_list()
-        )
+    def __set_cpus_containers(self, core_affinity_offsets, container_list):
+        if core_affinity_offsets is None:
+            pre_selected_cpus = None
+            # determine m
+            num_avail_cpus = self.topo.get_core_count() if self.policy.one_cpu_per_core else self.topo.get_cpu_count()
+        else:
+            pre_selected_cpus = ListConfig.from_dict(core_affinity_offsets).get_list()
+            # if the user wants specific CPUs then we use what the user specified as the max
+            num_avail_cpus = len(pre_selected_cpus)
+
+        if container_list is None:
+            # if the user did not configure how many containers to run with
+            # we generate a list from 1 -> max to run with, where max will be the maximum
+            # number of containers we can run with without causing oversubscription
+            max_num_containers = num_avail_cpus // self.core_count
+            bm_log(f"""
+                   Maximum number of container we can use without causing oversubscription is {max_num_containers}.
+                   {self.core_count} CPUs will be used per container.
+                   {num_avail_cpus} CPUs are available in total.
+            """)
+            self.container_list = self.__gen_container_list(max=max_num_containers, cpus_per_container= self.core_count)
+        else:
+            self.container_list = ListConfig.from_dict(container_list).get_list()
+
         # Calculate the maximum number of CPUs needed.
         # max number of containers * cores per container
         max_cpu_count = max(self.container_list) * self.core_count
@@ -110,23 +120,7 @@ class ContainersConfig(dict):
         default_container_list.remove(0)
         if default_container_list[0] != 1:
             default_container_list.insert(0, 1)  # replace zero with 1
-
-        bm_log(
-            f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}",
-            LogType.INFO,
-        )
         return default_container_list
-
-    def __get_default_container_list(self) -> list[int]:
-        cpus_per_container = self.core_count
-        if self.policy.one_cpu_per_core:
-            # if hyper-threads are not allowed we define the max
-            # based on core count
-            max = math.floor(self.topo.get_core_count() / cpus_per_container)
-        else:
-            # if hyper-threads are allowed we define it based on the CPU count
-            max = math.floor(self.topo.get_cpu_count() / cpus_per_container)
-        return self.__gen_container_list(max=max, cpus_per_container=cpus_per_container)
 
     def get_container_cnt_list(self) -> list[int]:
         return self.container_list

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -107,9 +107,12 @@ class ContainersConfig(dict):
         if max < num_steps:
             step = 1
         else:
-            step = (max // num_steps) - 1
+            step = (max // num_steps)
 
-        default_container_list = list(range(1, max+1, step))
+        default_container_list = list(range(0, max+1, step))
+        assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
+        default_container_list.insert(0, 1) # replace zero with 1
+
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
         return default_container_list
 

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -107,7 +107,7 @@ class ContainersConfig(dict):
         if max < num_steps:
             step = 1
         else:
-            step = max // num_steps
+            step = (max // num_steps) - 1
 
         default_container_list = list(range(1, max+1, step))
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -6,10 +6,12 @@ from config.list import ListConfig
 import docker
 import docker.errors
 import sys
+import math
 from utils.logger import bm_log, LogType
 from utils.platform import get_os, OperatingSystem
 from utils.topology import Topology
 from config.policy import CoreAssignPolicy
+from bm_utils import closest_divisor_10_percent
 
 
 class ContainersConfig(dict):
@@ -22,7 +24,7 @@ class ContainersConfig(dict):
 
     def __init__(
         self,
-        container_list: ListConfig = ListConfig(values=[[1]]),
+        container_list: Optional[ListConfig] = None,
         core_assignment_policy: CoreAssignPolicy = CoreAssignPolicy(),
         core_affinity_offsets: Optional[ListConfig] = None,
         core_count: int = 1,
@@ -68,8 +70,15 @@ class ContainersConfig(dict):
         self.cpus: list[int]
         self.policy: CoreAssignPolicy
         self.topo = Topology()
-        self.container_list = ListConfig.from_dict(container_list).get_list()
         self.core_count = core_count
+        if container_list is None:
+           max  = math.floor(self.topo.get_cpu_count() / self.core_count)
+           step = closest_divisor_10_percent(max)
+           self.container_list  = list(range(1, max+1, step))
+           bm_log(f"Identified the step: {step}", LogType.WARNING)
+        else:
+            self.container_list = ListConfig.from_dict(container_list).get_list()
+        bm_log(self.container_list, LogType.WARNING)
         self.__set_cpus(policy=core_assignment_policy, core_affinity_offsets=core_affinity_offsets)
         self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
         self.name = name

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -112,7 +112,8 @@ class ContainersConfig(dict):
         default_container_list = list(range(0, max+1, step))
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
         default_container_list.remove(0)
-        default_container_list[0] = 1 # replace zero with 1
+        if default_container_list[0] != 1:
+            default_container_list.insert(0, 1) # replace zero with 1
 
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
         return default_container_list

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -35,9 +35,9 @@ class ContainersConfig(dict):
         Represented as a JSON object.
         Parameters
         ----------
-        container_list: ListConfig = {"values": [[1]]}
-            Specifies the number of containers to run.
-        one_cpu_per_core: bool = False,
+        container_list: Optional[ListConfig] = dynamically computed.
+            Specifies the number of containers to run. When `container_list` is absent in the configuration,
+            the default value is dynamically computed based on the number of available CPUs/Cores on the target machine.
         core_assignment_policy: CoreAssignPolicy = {"pack_group":"none", "cpu_order": "asc", "one_cpu_per_core": false}
             Configures the CPU assignment policy, i.e. which CPUs can be assigned to execution units (containers/native processes).
             Note that the policy is overwritten by `core_affinity_offsets`. If the users wish to use this configuration, they

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -111,6 +111,7 @@ class ContainersConfig(dict):
 
         default_container_list = list(range(0, max+1, step))
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
+        default_container_list.remove(0)
         default_container_list[0] = 1 # replace zero with 1
 
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -68,24 +68,17 @@ class ContainersConfig(dict):
             core_assignment_policy=core_assignment_policy,
         )
         self.cpus: list[int]
-        self.policy: CoreAssignPolicy
         self.topo = Topology()
         self.core_count = core_count
-        if container_list is None:
-           max  = math.floor(self.topo.get_cpu_count() / self.core_count)
-           step = closest_divisor_10_percent(max)
-           self.container_list  = list(range(1, max+1, step))
-           bm_log(f"Identified the step: {step}", LogType.WARNING)
-        else:
-            self.container_list = ListConfig.from_dict(container_list).get_list()
-        bm_log(self.container_list, LogType.WARNING)
-        self.__set_cpus(policy=core_assignment_policy, core_affinity_offsets=core_affinity_offsets)
+        self.policy = CoreAssignPolicy.from_dict(core_assignment_policy)
+        self.container_list = self.__get_default_container_list() if container_list is None else ListConfig.from_dict(container_list).get_list()
+        self.__set_cpus(core_affinity_offsets=core_affinity_offsets)
         self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
         self.name = name
         self.port = port
         self.__ensure_img_exists()
 
-    def __set_cpus(self, policy, core_affinity_offsets):
+    def __set_cpus(self, core_affinity_offsets):
         """
         Selects which CPUs are allowed to be used according to the
         policy and core_affinity_offsets.
@@ -95,13 +88,27 @@ class ContainersConfig(dict):
             if core_affinity_offsets is None
             else ListConfig.from_dict(core_affinity_offsets).get_list()
         )
-        self.policy = CoreAssignPolicy.from_dict(policy)
         # Calculate the maximum number of CPUs needed.
         # max number of containers * cores per container
         max_cpu_count = max(self.container_list) * self.core_count
         self.cpus = self.topo.select(
             count=max_cpu_count, policy=self.policy, pre_selected=pre_selected_cpus
         )
+
+    def __get_default_container_list(self) -> list[int]:
+        cpus_per_container = self.core_count
+        if self.policy.one_cpu_per_core:
+            # if hyper-threads are not allowed we define the max
+            # based on core count
+            max  = math.floor(self.topo.get_core_count() / cpus_per_container)
+        else:
+            # if hyper-threads are allowed we define it based on the CPU count
+            max  = math.floor(self.topo.get_cpu_count() / cpus_per_container)
+        # define the step based on maximum number of containers
+        step = closest_divisor_10_percent(max)
+        default_container_list = list(range(1, max+1, step))
+        bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
+        return default_container_list
 
     def get_container_cnt_list(self) -> list[int]:
         return self.container_list

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -13,6 +13,7 @@ from config.policy import CoreAssignPolicy, PackGroup
 
 
 class ContainersConfig(dict):
+    NUM_STEPS: int = 16  # default number of steps to set default container_list
     CONFIG_KEY: str = "containers"
     DEFAULT_IMG: dict[OperatingSystem, str] = {
         OperatingSystem.openEuler: "hub.oepkgs.net/openeuler/openeuler",
@@ -79,9 +80,14 @@ class ContainersConfig(dict):
         self.__ensure_img_exists()
 
     def __set_cpus_containers(self, core_affinity_offsets, container_list):
+        """
+        Sets self.container_list and self.cpus
+
+        """
         if core_affinity_offsets is None:
             pre_selected_cpus = None
-            # determine m
+            # we decide number of available CPUs based on the policy.
+            # we use number of cores if the policy requests one CPU per core.
             num_avail_cpus = (
                 self.topo.get_core_count()
                 if self.policy.one_cpu_per_core
@@ -89,12 +95,12 @@ class ContainersConfig(dict):
             )
         else:
             pre_selected_cpus = ListConfig.from_dict(core_affinity_offsets).get_list()
-            # if the user wants specific CPUs then we use what the user specified as the max
+            # if the user wants specific CPUs then we use the count of the specified CPUs.
             num_avail_cpus = len(pre_selected_cpus)
 
         if container_list is None:
-            # if the user did not configure how many containers to run with
-            # we generate a list from 1 -> max to run with, where max will be the maximum
+            # if the user did not configure how many containers to run
+            # we generate a list from 1 -> max, where max will be the maximum
             # number of containers we can run with without causing oversubscription
             max_num_containers = num_avail_cpus // self.core_count
             bm_log(
@@ -105,7 +111,6 @@ class ContainersConfig(dict):
             """
             )
             self.container_list = self.__gen_container_list(max_num_containers)
-            # do not multiply by core count here, because that is already factored in
             max_cpu_count = max(self.container_list)
             # at the moment we don't respect the pack group policy when
             # determining max #containers, hence when the policy is set to pack by
@@ -133,15 +138,14 @@ class ContainersConfig(dict):
         )
 
     def __gen_container_list(self, max_num_containers) -> list[int]:
-        NUM_STEPS = 16
-        if max_num_containers < NUM_STEPS:
+        if max_num_containers < self.NUM_STEPS:
             step = 1
             max = max_num_containers
         else:
             # find the closest number to max_num_containers that is divisible by NUM_STEPS
             # and does not exceed it
-            max = (max_num_containers // NUM_STEPS) * NUM_STEPS
-            step = max // NUM_STEPS
+            max = (max_num_containers // self.NUM_STEPS) * self.NUM_STEPS
+            step = max // self.NUM_STEPS
 
         # we start range from zero and use max + 1, so that the last value will max
         default_container_list = list(range(0, max + 1, step))

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -111,13 +111,15 @@ class ContainersConfig(dict):
             # determining max #containers, hence when the policy is set to pack by
             # e.g NUMA this can lead to oversubscription. For the time being
             # we treat it as a misconfiguration.
-            if self.policy.pack_group !=  PackGroup.NO_PACK:
-                bm_log("""
+            if self.policy.pack_group != PackGroup.NO_PACK:
+                bm_log(
+                    """
                        Expecting "pack_group": "none" in configuration, or
                        absent "core_assignment_policy", when default "container_list"
                        is dynamically computed. CPUs oversubscription might occur.
-                       """
-                       , LogType.ERROR)
+                       """,
+                    LogType.ERROR,
+                )
                 # we don't need to quit, the run can still be useful if the user
                 # does not want to interrupt it, and is ok with oversubscription.
         else:

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -107,7 +107,7 @@ class ContainersConfig(dict):
         if max < num_steps:
             step = 1
         else:
-            step = max / num_steps
+            step = max // num_steps
 
         default_container_list = list(range(1, max+1, step))
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -6,7 +6,6 @@ from config.list import ListConfig
 import docker
 import docker.errors
 import sys
-import math
 from utils.logger import bm_log, LogType
 from utils.platform import get_os, OperatingSystem
 from utils.topology import Topology
@@ -74,14 +73,20 @@ class ContainersConfig(dict):
         self.name = name
         self.port = port
         # needs some of the previous fields to be set
-        self.__set_cpus_containers(core_affinity_offsets=core_affinity_offsets, container_list=container_list)
+        self.__set_cpus_containers(
+            core_affinity_offsets=core_affinity_offsets, container_list=container_list
+        )
         self.__ensure_img_exists()
 
     def __set_cpus_containers(self, core_affinity_offsets, container_list):
         if core_affinity_offsets is None:
             pre_selected_cpus = None
             # determine m
-            num_avail_cpus = self.topo.get_core_count() if self.policy.one_cpu_per_core else self.topo.get_cpu_count()
+            num_avail_cpus = (
+                self.topo.get_core_count()
+                if self.policy.one_cpu_per_core
+                else self.topo.get_cpu_count()
+            )
         else:
             pre_selected_cpus = ListConfig.from_dict(core_affinity_offsets).get_list()
             # if the user wants specific CPUs then we use what the user specified as the max
@@ -92,12 +97,16 @@ class ContainersConfig(dict):
             # we generate a list from 1 -> max to run with, where max will be the maximum
             # number of containers we can run with without causing oversubscription
             max_num_containers = num_avail_cpus // self.core_count
-            bm_log(f"""
+            bm_log(
+                f"""
                    Maximum number of container we can use without causing oversubscription is {max_num_containers}.
                    {self.core_count} CPUs will be used per container.
                    {num_avail_cpus} CPUs are available in total.
-            """)
-            self.container_list = self.__gen_container_list(max=max_num_containers, cpus_per_container= self.core_count)
+            """
+            )
+            self.container_list = self.__gen_container_list(
+                max=max_num_containers, cpus_per_container=self.core_count
+            )
         else:
             self.container_list = ListConfig.from_dict(container_list).get_list()
 

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -93,17 +93,8 @@ class ContainersConfig(dict):
             count=max_cpu_count, policy=self.policy, pre_selected=pre_selected_cpus
         )
 
-    def __get_default_container_list(self) -> list[int]:
-        cpus_per_container = self.core_count
+    def __get_gen_list(self, max, cpus_per_container) -> list[int]:
         num_steps = 16
-        if self.policy.one_cpu_per_core:
-            # if hyper-threads are not allowed we define the max
-            # based on core count
-            max  = math.floor(self.topo.get_core_count() / cpus_per_container)
-        else:
-            # if hyper-threads are allowed we define it based on the CPU count
-            max  = math.floor(self.topo.get_cpu_count() / cpus_per_container)
-
         if max < num_steps:
             step = 1
         else:
@@ -117,6 +108,20 @@ class ContainersConfig(dict):
 
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
         return default_container_list
+
+    def __get_default_container_list(self) -> list[int]:
+        cpus_per_container = self.core_count
+        if self.policy.one_cpu_per_core:
+            # if hyper-threads are not allowed we define the max
+            # based on core count
+            max  = math.floor(self.topo.get_core_count() / cpus_per_container)
+        else:
+            # if hyper-threads are allowed we define it based on the CPU count
+            max  = math.floor(self.topo.get_cpu_count() / cpus_per_container)
+
+            return self.__get_gen_list(max=max, cpus_per_container=cpus_per_container)
+
+
 
     def get_container_cnt_list(self) -> list[int]:
         return self.container_list

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -87,6 +87,7 @@ class ContainersConfig(dict):
                 if self.policy.one_cpu_per_core
                 else self.topo.get_cpu_count()
             )
+            bm_log(f"#CPUS: {self.topo.get_core_count()}, #Cores: {self.topo.get_cpu_count()}", LogType.FATAL)
         else:
             pre_selected_cpus = ListConfig.from_dict(core_affinity_offsets).get_list()
             # if the user wants specific CPUs then we use what the user specified as the max

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -9,7 +9,7 @@ import sys
 from utils.logger import bm_log, LogType
 from utils.platform import get_os, OperatingSystem
 from utils.topology import Topology
-from config.policy import CoreAssignPolicy
+from config.policy import CoreAssignPolicy, PackGroup
 
 
 class ContainersConfig(dict):
@@ -87,7 +87,6 @@ class ContainersConfig(dict):
                 if self.policy.one_cpu_per_core
                 else self.topo.get_cpu_count()
             )
-            bm_log(f"#CPUS: {self.topo.get_core_count()}, #Cores: {self.topo.get_cpu_count()}", LogType.FATAL)
         else:
             pre_selected_cpus = ListConfig.from_dict(core_affinity_offsets).get_list()
             # if the user wants specific CPUs then we use what the user specified as the max
@@ -108,6 +107,13 @@ class ContainersConfig(dict):
             self.container_list = self.__gen_container_list(max_num_containers)
             # do not multiply by core count here, because that is already factored in
             max_cpu_count = max(self.container_list)
+            if self.policy.pack_group !=  PackGroup.NO_PACK:
+                bm_log("""
+                       Expecting "pack_group": "none" in configuration, or
+                       absent "core_assignment_policy", when default "container_list"
+                       is dynamically computed. CPUs oversubscription might occur.
+                       """
+                       , LogType.ERROR)
         else:
             self.container_list = ListConfig.from_dict(container_list).get_list()
             # Calculate the maximum number of CPUs needed.

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -12,6 +12,7 @@ from utils.platform import get_os, OperatingSystem
 from utils.topology import Topology
 from config.policy import CoreAssignPolicy
 
+
 class ContainersConfig(dict):
     CONFIG_KEY: str = "containers"
     DEFAULT_IMG: dict[OperatingSystem, str] = {
@@ -69,7 +70,11 @@ class ContainersConfig(dict):
         self.topo = Topology()
         self.core_count = core_count
         self.policy = CoreAssignPolicy.from_dict(core_assignment_policy)
-        self.container_list = self.__get_default_container_list() if container_list is None else ListConfig.from_dict(container_list).get_list()
+        self.container_list = (
+            self.__get_default_container_list()
+            if container_list is None
+            else ListConfig.from_dict(container_list).get_list()
+        )
         self.__set_cpus(core_affinity_offsets=core_affinity_offsets)
         self.image = image if image is not None else self.DEFAULT_IMG[get_os()]
         self.name = name
@@ -98,15 +103,18 @@ class ContainersConfig(dict):
         if max < num_steps:
             step = 1
         else:
-            step = (max // num_steps)
+            step = max // num_steps
 
-        default_container_list = list(range(0, max+1, step))
+        default_container_list = list(range(0, max + 1, step))
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
         default_container_list.remove(0)
         if default_container_list[0] != 1:
-            default_container_list.insert(0, 1) # replace zero with 1
+            default_container_list.insert(0, 1)  # replace zero with 1
 
-        bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
+        bm_log(
+            f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}",
+            LogType.INFO,
+        )
         return default_container_list
 
     def __get_default_container_list(self) -> list[int]:
@@ -114,10 +122,10 @@ class ContainersConfig(dict):
         if self.policy.one_cpu_per_core:
             # if hyper-threads are not allowed we define the max
             # based on core count
-            max  = math.floor(self.topo.get_core_count() / cpus_per_container)
+            max = math.floor(self.topo.get_core_count() / cpus_per_container)
         else:
             # if hyper-threads are allowed we define it based on the CPU count
-            max  = math.floor(self.topo.get_cpu_count() / cpus_per_container)
+            max = math.floor(self.topo.get_cpu_count() / cpus_per_container)
         return self.__gen_container_list(max=max, cpus_per_container=cpus_per_container)
 
     def get_container_cnt_list(self) -> list[int]:

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -107,6 +107,10 @@ class ContainersConfig(dict):
             self.container_list = self.__gen_container_list(max_num_containers)
             # do not multiply by core count here, because that is already factored in
             max_cpu_count = max(self.container_list)
+            # at the moment we don't respect the pack group policy when
+            # determining max #containers, hence when the policy is set to pack by
+            # e.g NUMA this can lead to oversubscription. For the time being
+            # we treat it as a misconfiguration.
             if self.policy.pack_group !=  PackGroup.NO_PACK:
                 bm_log("""
                        Expecting "pack_group": "none" in configuration, or
@@ -114,6 +118,8 @@ class ContainersConfig(dict):
                        is dynamically computed. CPUs oversubscription might occur.
                        """
                        , LogType.ERROR)
+                # we don't need to quit, the run can still be useful if the user
+                # does not want to interrupt it, and is ok with oversubscription.
         else:
             self.container_list = ListConfig.from_dict(container_list).get_list()
             # Calculate the maximum number of CPUs needed.

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -104,9 +104,7 @@ class ContainersConfig(dict):
                    {num_avail_cpus} CPUs are available in total.
             """
             )
-            self.container_list = self.__gen_container_list(
-                max=max_num_containers, cpus_per_container=self.core_count
-            )
+            self.container_list = self.__gen_container_list(max_num_containers)
         else:
             self.container_list = ListConfig.from_dict(container_list).get_list()
 
@@ -117,18 +115,26 @@ class ContainersConfig(dict):
             count=max_cpu_count, policy=self.policy, pre_selected=pre_selected_cpus
         )
 
-    def __gen_container_list(self, max, cpus_per_container) -> list[int]:
-        num_steps = 16
-        if max < num_steps:
+    def __gen_container_list(self, max_num_containers) -> list[int]:
+        NUM_STEPS = 16
+        if max_num_containers < NUM_STEPS:
             step = 1
+            max = max_num_containers
         else:
-            step = max // num_steps
+            # find the closest number to max_num_containers that is divisible by NUM_STEPS
+            # and does not exceed it
+            max = (max_num_containers // NUM_STEPS) * NUM_STEPS
+            step = max // NUM_STEPS
 
+        # we start range from zero and use max + 1, so that the last value will max
         default_container_list = list(range(0, max + 1, step))
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
+        # we remove zero from the list
         default_container_list.remove(0)
+        # make sure first element of the list is one
         if default_container_list[0] != 1:
-            default_container_list.insert(0, 1)  # replace zero with 1
+            # insert don't overwrite
+            default_container_list.insert(0, 1)
         return default_container_list
 
     def get_container_cnt_list(self) -> list[int]:

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -111,7 +111,7 @@ class ContainersConfig(dict):
 
         default_container_list = list(range(0, max+1, step))
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
-        default_container_list.insert(0, 1) # replace zero with 1
+        default_container_list[0] = 1 # replace zero with 1
 
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
         return default_container_list

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -11,8 +11,6 @@ from utils.logger import bm_log, LogType
 from utils.platform import get_os, OperatingSystem
 from utils.topology import Topology
 from config.policy import CoreAssignPolicy
-from bm_utils import closest_divisor_10_percent
-
 
 class ContainersConfig(dict):
     CONFIG_KEY: str = "containers"
@@ -97,6 +95,7 @@ class ContainersConfig(dict):
 
     def __get_default_container_list(self) -> list[int]:
         cpus_per_container = self.core_count
+        num_steps = 16
         if self.policy.one_cpu_per_core:
             # if hyper-threads are not allowed we define the max
             # based on core count
@@ -104,8 +103,12 @@ class ContainersConfig(dict):
         else:
             # if hyper-threads are allowed we define it based on the CPU count
             max  = math.floor(self.topo.get_cpu_count() / cpus_per_container)
-        # define the step based on maximum number of containers
-        step = closest_divisor_10_percent(max)
+
+        if max < num_steps:
+            step = 1
+        else:
+            step = max / num_steps
+
         default_container_list = list(range(1, max+1, step))
         bm_log(f"Defined container list with step={step}, cpus_per_contianer={cpus_per_container} to be {default_container_list}", LogType.INFO)
         return default_container_list

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -32,4 +32,3 @@ def test_gen_container_list_defaults():
             assert (
                 container_counts[0] == 1
             ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}"
-

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -1,3 +1,6 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
 from config.container import ContainersConfig
 
 

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -6,9 +6,9 @@ from config.container import ContainersConfig
 
 def test_gen_container_list_defaults():
     container_cfg = ContainersConfig()
-    num_steps = 16
+    num_steps = container_cfg.NUM_STEPS
 
-    # alias private function once
+    # alias private function
     gen_list = container_cfg._ContainersConfig__gen_container_list  # type: ignore[attr-defined]
 
     # Test: list length matches requested steps
@@ -17,6 +17,7 @@ def test_gen_container_list_defaults():
         assert len(container_counts) == steps, f"Failed for steps={steps}"
 
     # Test: common core counts produce expected length and first element
+    # this is the case we care about the most
     common_core_counts = [32, 96, 384, 192, 256, 320, 160]
     for num_cores in common_core_counts:
         container_counts = gen_list(num_cores)
@@ -32,3 +33,5 @@ def test_gen_container_list_defaults():
             assert (
                 container_counts[0] == 1
             ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}"
+
+    # There are edge cases that we don't have specific expectations for.

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -1,29 +1,27 @@
-
 from config.container import ContainersConfig
+
 
 def test_defaults():
     containerCfg = ContainersConfig()
     num_steps = 16
     # alias private function
-    gen_list = containerCfg._ContainersConfig__gen_container_list
+    gen_list = containerCfg._ContainersConfig__gen_container_list  # type: ignore[attr-defined]
 
     # test
     for i in range(1, num_steps + 1):
-      assert(len(gen_list(i, 1)) == i)
+        assert len(gen_list(i, 1)) == i
 
     # test most common values
     values = [32, 96, 384, 192, 256, 320, 160]
     for v in values:
-       counts = gen_list(v, 1)
-       assert len(counts) == num_steps + 1
-       assert counts[0] == 1
+        counts = gen_list(v, 1)
+        assert len(counts) == num_steps + 1
+        assert counts[0] == 1
 
     # try some odd combinations
     cores_per_container = [2, 3, 7]
     for v in values:
-       for c in cores_per_container:
-          max = v//c
-          counts = gen_list(max, c)
-          assert(counts[0] == 1)
-
-
+        for c in cores_per_container:
+            max = v // c
+            counts = gen_list(max, c)
+            assert counts[0] == 1

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -4,27 +4,32 @@
 from config.container import ContainersConfig
 
 
-def test_defaults():
-    containerCfg = ContainersConfig()
+def test_gen_container_list_defaults():
+    container_cfg = ContainersConfig()
     num_steps = 16
-    # alias private function
-    gen_list = containerCfg._ContainersConfig__gen_container_list  # type: ignore[attr-defined]
 
-    # test
-    for i in range(1, num_steps + 1):
-        assert len(gen_list(i, 1)) == i
+    # alias private function once
+    gen_list = container_cfg._ContainersConfig__gen_container_list  # type: ignore[attr-defined]
 
-    # test most common values
-    values = [32, 96, 384, 192, 256, 320, 160]
-    for v in values:
-        counts = gen_list(v, 1)
-        assert len(counts) == num_steps + 1
-        assert counts[0] == 1
+    # Test: list length matches requested steps
+    for steps in range(1, num_steps + 1):
+        container_counts = gen_list(steps)
+        assert len(container_counts) == steps, f"Failed for steps={steps}"
 
-    # try some odd combinations
-    cores_per_container = [2, 3, 7]
-    for v in values:
-        for c in cores_per_container:
-            max = v // c
-            counts = gen_list(max, c)
-            assert counts[0] == 1
+    # Test: common core counts produce expected length and first element
+    common_core_counts = [32, 96, 384, 192, 256, 320, 160]
+    for num_cores in common_core_counts:
+        container_counts = gen_list(num_cores)
+        assert len(container_counts) == num_steps + 1, f"Failed for num_cores={num_cores}"
+        assert container_counts[0] == 1, f"First element should be 1 for num_cores={num_cores}"
+
+    # Test: numbers less than number of steps
+    cores_per_container_list = [2, 3, 7]
+    for num_cores in common_core_counts:
+        for cores_per_container in cores_per_container_list:
+            max_containers = num_cores // cores_per_container
+            container_counts = gen_list(max_containers)
+            assert (
+                container_counts[0] == 1
+            ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}"
+

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -9,7 +9,7 @@ def test_gen_container_list_defaults():
     num_steps = container_cfg.NUM_STEPS
 
     # alias private function
-    gen_list = container_cfg._ContainersConfig__gen_container_list  # type: ignore[attr-defined]
+    gen_list = getattr(container_cfg, "_ContainersConfig__gen_container_list")
 
     # Test: list length matches requested steps
     for steps in range(1, num_steps + 1):

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -1,0 +1,29 @@
+
+from config.container import ContainersConfig
+
+def test_defaults():
+    containerCfg = ContainersConfig()
+    num_steps = 16
+    # alias private function
+    gen_list = containerCfg._ContainersConfig__gen_container_list
+
+    # test
+    for i in range(1, num_steps + 1):
+      assert(len(gen_list(i, 1)) == i)
+
+    # test most common values
+    values = [32, 96, 384, 192, 256, 320, 160]
+    for v in values:
+       counts = gen_list(v, 1)
+       assert len(counts) == num_steps + 1
+       assert counts[0] == 1
+
+    # try some odd combinations
+    cores_per_container = [2, 3, 7]
+    for v in values:
+       for c in cores_per_container:
+          max = v//c
+          counts = gen_list(max, c)
+          assert(counts[0] == 1)
+
+

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -35,20 +35,11 @@
     "duration": 1
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1,
-          5,
-          10
-        ]
-      ]
-    },
     "core_count": 3,
     "core_assignment_policy": {
       "cpu_order": "desc",
       "pack_group": "numa",
-      "one_cpu_per_core": true
+      "one_cpu_per_core": false
     }
   },
   "applications": [

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -37,7 +37,7 @@
   "containers": {
     "core_assignment_policy": {
       "cpu_order": "desc",
-      "pack_group": "numa",
+      "pack_group": "none",
       "one_cpu_per_core": true
     }
   },

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -35,7 +35,6 @@
     "duration": 1
   },
   "containers": {
-    "core_count": 3,
     "core_assignment_policy": {
       "cpu_order": "desc",
       "pack_group": "numa",

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -38,7 +38,7 @@
     "core_assignment_policy": {
       "cpu_order": "desc",
       "pack_group": "numa",
-      "one_cpu_per_core": false
+      "one_cpu_per_core": true
     }
   },
   "applications": [

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -39,7 +39,7 @@ ContainersConfig represents the configuration for multiple containers. Represent
 <br/>***JSON key: "containers"***
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|container_list|[ListConfig](#listconfig)|:white_check_mark:|`{"values": [[1]]}`|    Specifies the number of containers to run. |
+|container_list|[ListConfig](#listconfig)|:white_check_mark:|`dynamically computed.`|    Specifies the number of containers to run. When `container_list` is absent in the configuration,     the default value is dynamically computed based on the number of available CPUs/Cores on the target machine. |
 |core_assignment_policy|[CoreAssignPolicy](#coreassignpolicy)|:white_check_mark:|`{"pack_group":"none", "cpu_order": "asc", "one_cpu_per_core": false}`|    Configures the CPU assignment policy, i.e. which CPUs can be assigned to execution units (containers/native processes).     Note that the policy is overwritten by `core_affinity_offsets`. If the users wish to use this configuration, they     should make sure not to specify `core_affinity_offsets`. |
 |core_affinity_offsets|[ListConfig](#listconfig)|:white_check_mark:|`core_count * [0, 1, 2, 3, ...]`|    Specifies the cores that should be assigned to the containers.     Note that the assignment of cores happens in ascending order by default.     This configuration overwrites `core_assignment_policy`. |
 |core_count|int|:white_check_mark:|`1`|    Number of cores to assign to each container. |


### PR DESCRIPTION
Change

- allow `container_list` config to be optional
- change the default value of  `container_list` from `1`
  to be a list that can reach up to #cores of the target machine
  auto-compute the step and the max respecting given
  policy and or affinity offsets.

Add

- some basic sanity testing of `__gen_container_list`
