### PR TITLE
[bm-runner] Improve the logic of dynamically set default `container_list`

### DIFF
--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -13,7 +13,8 @@ from config.policy import CoreAssignPolicy, PackGroup
 
 
 class ContainersConfig(dict):
-    NUM_STEPS: int = 16  # default number of steps to set default container_list
+    MIN_NUM_STEPS: int = 6  # default minimum number of steps to set default container_list
+    MAX_NUM_STEPS: int = 10  # default maximum number of steps to set default container_list
     CONFIG_KEY: str = "containers"
     DEFAULT_IMG: dict[OperatingSystem, str] = {
         OperatingSystem.openEuler: "hub.oepkgs.net/openeuler/openeuler",
@@ -138,16 +139,30 @@ class ContainersConfig(dict):
         )
 
     def __gen_container_list(self, max_num_containers) -> list[int]:
-        if max_num_containers < self.NUM_STEPS:
+        num_steps = int((self.MIN_NUM_STEPS + self.MAX_NUM_STEPS) / 2)
+        if num_steps < 1:
+            num_steps = 1
+        if max_num_containers < 1:
+            max_num_containers = 1
+        if max_num_containers < num_steps:
             step = 1
             max = max_num_containers
         else:
             # find the closest number to max_num_containers that is divisible by NUM_STEPS
             # and does not exceed it
-            max = (max_num_containers // self.NUM_STEPS) * self.NUM_STEPS
-            step = max // self.NUM_STEPS
+            max = (max_num_containers // num_steps) * num_steps
+            step = (max // num_steps)
+            if step < 1:
+                step = 1
+            while (max // step) > self.MAX_NUM_STEPS:
+                print(f"double step from {step} ({max // step})")
+                step = step * 2
+            while step > 1 and (max // step) < self.MIN_NUM_STEPS:
+                print("half step")
+                step = step / 2
 
         # we start range from zero and use max + 1, so that the last value will max
+        # Always add 1 and max_num_containers
         default_container_list = list(range(0, max + 1, step))
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
         # we remove zero from the list
@@ -156,6 +171,9 @@ class ContainersConfig(dict):
         if default_container_list[0] != 1:
             # insert don't overwrite
             default_container_list.insert(0, 1)
+        if default_container_list[-1] != max_num_containers:
+            default_container_list.append(max_num_containers)
+
         return default_container_list
 
     def get_container_cnt_list(self) -> list[int]:

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -151,15 +151,13 @@ class ContainersConfig(dict):
             # find the closest number to max_num_containers that is divisible by NUM_STEPS
             # and does not exceed it
             max = (max_num_containers // num_steps) * num_steps
-            step = (max // num_steps)
+            step = max // num_steps
             if step < 1:
                 step = 1
             while (max // step) > self.MAX_NUM_STEPS:
-                print(f"double step from {step} ({max // step})")
                 step = step * 2
             while step > 1 and (max // step) < self.MIN_NUM_STEPS:
-                print("half step")
-                step = step / 2
+                step = step // 2
 
         # we start range from zero and use max + 1, so that the last value will max
         # Always add 1 and max_num_containers

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -1,9 +1,9 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import sys
 from config.container import ContainersConfig
 from utils.logger import bm_log
+
 
 def test_gen_container_list_defaults():
     container_cfg = ContainersConfig()
@@ -27,17 +27,21 @@ def test_gen_container_list_defaults():
         bm_log(f"num_cores={num_cores} ({len(container_counts)} tests): {container_counts}")
         assert len(container_counts) >= min_steps, f"Failed for num_cores={num_cores}"
         assert len(container_counts) <= max_steps + 2, f"Failed for num_cores={num_cores}"
-        assert container_counts[0] == 1, f"First element should be 1 for num_cores={num_cores}: {container_counts}"
+        assert (
+            container_counts[0] == 1
+        ), f"First element should be 1 for num_cores={num_cores}: {container_counts}"
         assert (
             container_counts[-1] == num_cores
-        ), f"Last element should be num_cores={num_cores}, cores_per_container={cores_per_container}: {container_counts}"
+        ), f"Last element should be num_cores={num_cores}, container_list: {container_counts}"
     # Test: numbers less than number of steps
     cores_per_container_list = [1, 2, 3, 4, 7]
     for num_cores in common_core_counts:
         for cores_per_container in cores_per_container_list:
             max_containers = num_cores // cores_per_container
             container_counts = gen_list(max_containers)
-            bm_log(f"max_containers={max_containers} ({len(container_counts)} tests): {container_counts}")
+            bm_log(
+                f"max_containers={max_containers} ({len(container_counts)} tests): {container_counts}"
+            )
             assert (
                 container_counts[0] == 1
             ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}: {container_counts}"

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -1,37 +1,46 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+import sys
 from config.container import ContainersConfig
-
+from utils.logger import bm_log
 
 def test_gen_container_list_defaults():
     container_cfg = ContainersConfig()
-    num_steps = container_cfg.NUM_STEPS
+    min_steps = container_cfg.MIN_NUM_STEPS
+    max_steps = container_cfg.MAX_NUM_STEPS
 
     # alias private function
     gen_list = getattr(container_cfg, "_ContainersConfig__gen_container_list")
 
     # Test: list length matches requested steps
-    for steps in range(1, num_steps + 1):
+    for steps in range(1, int((min_steps + max_steps) / 2) + 1):
         container_counts = gen_list(steps)
+        bm_log(f"steps={steps} ({len(container_counts)} tests): {container_counts}")
         assert len(container_counts) == steps, f"Failed for steps={steps}"
 
     # Test: common core counts produce expected length and first element
     # this is the case we care about the most
-    common_core_counts = [32, 96, 384, 192, 256, 320, 160]
+    common_core_counts = [6, 8, 12, 16, 24, 32, 88, 96, 160, 192, 256, 320, 384, 512]
     for num_cores in common_core_counts:
         container_counts = gen_list(num_cores)
-        assert len(container_counts) == num_steps + 1, f"Failed for num_cores={num_cores}"
-        assert container_counts[0] == 1, f"First element should be 1 for num_cores={num_cores}"
-
+        bm_log(f"num_cores={num_cores} ({len(container_counts)} tests): {container_counts}")
+        assert len(container_counts) >= min_steps, f"Failed for num_cores={num_cores}"
+        assert len(container_counts) <= max_steps + 2, f"Failed for num_cores={num_cores}"
+        assert container_counts[0] == 1, f"First element should be 1 for num_cores={num_cores}: {container_counts}"
+        assert (
+            container_counts[-1] == num_cores
+        ), f"Last element should be num_cores={num_cores}, cores_per_container={cores_per_container}: {container_counts}"
     # Test: numbers less than number of steps
-    cores_per_container_list = [2, 3, 7]
+    cores_per_container_list = [1, 2, 3, 4, 7]
     for num_cores in common_core_counts:
         for cores_per_container in cores_per_container_list:
             max_containers = num_cores // cores_per_container
             container_counts = gen_list(max_containers)
+            bm_log(f"max_containers={max_containers} ({len(container_counts)} tests): {container_counts}")
             assert (
                 container_counts[0] == 1
-            ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}"
+            ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}: {container_counts}"
+            assert len(container_counts) <= max_steps + 2, f"Failed for max_containers={num_cores}"
 
     # There are edge cases that we don't have specific expectations for.


### PR DESCRIPTION
Change

- change the logic in `__gen_container_list`.
- update related tests accordingly.
