### PR TITLE
[bm-runner] Add a new plot type

### DIFF
--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -40,6 +40,7 @@ def plot_chart(
     plot: PlotConfig,
     df: DataFrame,
     out_fig_name,
+    add_points = False,
     **kwargs,
 ):
     args = dict(kwargs)
@@ -69,6 +70,18 @@ def plot_chart(
         y=plot.y,
         **args,
     )
+    if add_points:
+        sns.scatterplot(
+            x=plot.x,
+            y=plot.y,
+            hue=plot.hue,
+            markers=plot.hue,
+            data=df,
+            hue_order=sorted_gp,
+            palette=palette,
+            ax=chart,
+            legend=False,
+        )
 
     chart.set(xlabel=plot.x_lbl, ylabel=plot.y_lbl)
     chart.grid(True)
@@ -318,6 +331,8 @@ def create_plots(df, plots: list[PlotConfig], dir, info: str):
                 create_histogram_plot(df=df, plot=plot, dir=dir)
             case PlotType.LINEARITY:
                 create_linearity_plot(df=df, plot=plot, dir=dir)
+            case PlotType.MEAN:
+                create_mean_plot(df=df, plot=plot, dir=dir)
             case _:
                 bm_log(f"unsupported plot type: {plot.type} skipped!", LogType.WARNING)
 
@@ -361,6 +376,14 @@ def split_data_frame(df: DataFrame) -> dict:
             frames[key] = df[(df["nb_threads"] == t) & (df["noise"] == n)]
     return frames
 
+def create_mean_plot(df: DataFrame, plot: PlotConfig, dir):
+    plot_chart(
+        plot=plot,
+        df=df,
+        out_fig_name=f"{dir}/{plot.y}_mean",
+        add_points=True,
+        estimator="mean",
+    )
 
 def create_linearity_plot(df: DataFrame, plot: PlotConfig, dir):
     count_col: str = plot.x  # e.g. container count

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -40,7 +40,7 @@ def plot_chart(
     plot: PlotConfig,
     df: DataFrame,
     out_fig_name,
-    add_points = False,
+    add_points=False,
     **kwargs,
 ):
     args = dict(kwargs)
@@ -376,6 +376,7 @@ def split_data_frame(df: DataFrame) -> dict:
             frames[key] = df[(df["nb_threads"] == t) & (df["noise"] == n)]
     return frames
 
+
 def create_mean_plot(df: DataFrame, plot: PlotConfig, dir):
     plot_chart(
         plot=plot,
@@ -384,6 +385,7 @@ def create_mean_plot(df: DataFrame, plot: PlotConfig, dir):
         add_points=True,
         estimator="mean",
     )
+
 
 def create_linearity_plot(df: DataFrame, plot: PlotConfig, dir):
     count_col: str = plot.x  # e.g. container count

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -12,6 +12,7 @@ class PlotType(str, Enum):
     Members
     ----------
     NORMAL: Plots according to the config no post processing of data.
+    MEAN: Plots the mean value of all execution units (throughput) per run.
     MIN_MAX_AVG: Experimental, Plots min, max and average time of operations.
     HISTOGRAM: Experimental, Plots the distribution of operations.
     SUCCESS_PERCENT: Experimental, Plots the percentage of successful operations.
@@ -19,6 +20,7 @@ class PlotType(str, Enum):
     """
 
     NORMAL = "normal"
+    MEAN = "mean"
     MIN_MAX_AVG = "min_max_avg"
     HISTOGRAM = "histogram"
     SUCCESS_PERCENT = "success_percent"
@@ -30,6 +32,7 @@ class PlotConfig(dict):
 
     DEFAULT_PLOT: dict[PlotType, str] = {
         PlotType.NORMAL: "lineplot",
+        PlotType.MEAN : "lineplot",
         PlotType.MIN_MAX_AVG: "barplot",
         PlotType.HISTOGRAM: "boxenplot",
         PlotType.SUCCESS_PERCENT: "barplot",

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -32,7 +32,7 @@ class PlotConfig(dict):
 
     DEFAULT_PLOT: dict[PlotType, str] = {
         PlotType.NORMAL: "lineplot",
-        PlotType.MEAN : "lineplot",
+        PlotType.MEAN: "lineplot",
         PlotType.MIN_MAX_AVG: "barplot",
         PlotType.HISTOGRAM: "boxenplot",
         PlotType.SUCCESS_PERCENT: "barplot",

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -12,7 +12,7 @@ class PlotType(str, Enum):
     Members
     ----------
     NORMAL: Plots according to the config no post processing of data.
-    MEAN: Plots the mean value of all execution units (throughput) per run.
+    MEAN: Plots the mean value of execution units' throughput (`y` value specified in plot config) per run.
     MIN_MAX_AVG: Experimental, Plots min, max and average time of operations.
     HISTOGRAM: Experimental, Plots the distribution of operations.
     SUCCESS_PERCENT: Experimental, Plots the percentage of successful operations.

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -17,6 +17,16 @@
       "y_lbl": "Throughput",
       "hue": "execution_type",
       "hue_lbl": "Execution Env",
+      "title": "Throughput mean vs. #Containers",
+      "type": "mean"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
+      "y": "throughput_min",
+      "y_lbl": "Throughput",
+      "hue": "execution_type",
+      "hue_lbl": "Execution Env",
       "title": "Linearity vs. #Containers",
       "type": "linearity"
     }
@@ -38,7 +48,7 @@
     "core_assignment_policy": {
       "cpu_order": "desc",
       "pack_group": "none",
-      "one_cpu_per_core": true
+      "one_cpu_per_core": false
     }
   },
   "applications": [

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -122,6 +122,7 @@ Monitors are used to monitor performance. They can be used to analyze the behavi
 ## PlotType
 Supported types of plots.  <br/>Supported values:
 - `"normal"`:  Plots according to the config no post processing of data.
+- `"mean"`:  Plots the mean value of execution units' throughput (`y` value specified in plot config) per run.
 - `"min_max_avg"`:  Experimental, Plots min, max and average time of operations.
 - `"histogram"`:  Experimental, Plots the distribution of operations.
 - `"success_percent"`:  Experimental, Plots the percentage of successful operations.


### PR DESCRIPTION
Change

- introduce `MEAN` plot, to plot the mean of 
  `y` value of multiple execution units per run
- introduce `add_points` argument in `plot_charts`