### PR TITLE
[bm-runner] Add `analyze.py` script.

### DIFF
--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -21,12 +21,13 @@ THROUGHPUT_FIELD    = 'throughput_min'
 COUNT_FIELD         = 'container_cnt'
 SUCCESS_FIELD       = 'univ_succ_percent'
 COMPARISON_FIELD    = 'kernel'
+EXEC_ENV_FIELD      = 'execution_type'
 MEASUREMENT_FIELD   = 'throughput_avg' # auto-computed
 LINEARITY_FIELD     = 'linearity' # auto-computed
 
 
 
-group_by_fields : list[str] = [BENCHMARK_FIELD, 'execution_type', 'hostname', COMPARISON_FIELD, 'nb_threads']
+group_by_fields : list[str] = [BENCHMARK_FIELD, EXEC_ENV_FIELD, 'hostname', COMPARISON_FIELD, 'nb_threads']
 
 
 output_dir_name = "analysis-results"
@@ -65,7 +66,7 @@ def process(file:str) -> list:
 
     return results
 
-def generate_patch_measurement(df, bm_name):
+def generate_patch_measurement(df, bm_name, env=""):
     subjects = df[COMPARISON_FIELD].unique()
     table = df.pivot_table(
         index=COUNT_FIELD,
@@ -77,10 +78,11 @@ def generate_patch_measurement(df, bm_name):
     md_table = table.to_markdown(index=False)
 
     md_info  = f"# {bm_name}\n"
+    md_info  += f"Execution environment: {env}\n"
 
-    write_to_file(dir=output_dir_name, fname=f"{bm_name}.md", content=md_info + md_table)
+    write_to_file(dir=output_dir_name, fname=f"{bm_name}-{env}.md", content=md_info + md_table)
 
-def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity'):
+def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', env=""):
     plot_cfg =  PlotConfig(
         hue="kernel",
         hue_lbl="Kernel",
@@ -88,22 +90,28 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity'):
         y_lbl=y_lbl,
         x=COUNT_FIELD,
         x_lbl="#Executions Units",
-        title=bm_name,
+        title=f"{bm_name}({env})",
     )
-    plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}-{y_lbl}")
+    plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}-{env}-{y_lbl}")
 
 
 def compare(df) -> str:
     benchmarks = df[BENCHMARK_FIELD].unique()
+    envs = df[EXEC_ENV_FIELD].unique()
     benchmarks.sort()
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
-        bm_df = df[(df[BENCHMARK_FIELD] == bm) &
-                   (df['execution_type'] == 'ExecutionType.CONTAINER')]
-        generate_patch_measurement(bm_df, bm)
-        generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average")
-        generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)")
-        generate_comparison_plot(bm_df, bm)
+        for env in envs:
+            bm_df = df[(df[BENCHMARK_FIELD] == bm) &
+                    (df['execution_type'] == env)]
+            if env == 'ExecutionType.CONTAINER':
+                nice_env = "container"
+            else:
+                nice_env = "native"
+            generate_patch_measurement(bm_df, bm, env=nice_env)
+            generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env)
+            generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)", env=nice_env)
+            generate_comparison_plot(bm_df, bm, env=nice_env)
 
 
 def get_files(folders):

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -59,43 +59,35 @@ def process(file:str) -> list:
 
     return results
 
-def gen_compare_summary(df) -> str:
+def generate_patch_measurement(df, bm_name):
+    bm_df = df[df['algo_name'] == bm_name]
+    subjects = bm_df['kernel'].unique()
+
+    table = bm_df.pivot_table(
+        index='container_cnt',
+        columns='kernel',
+        values='throughput_avg'
+    ).reset_index()
+
+    table = table[['container_cnt'] + list(subjects)]
+
+    md_table = table.to_markdown(index=False)
+    with open(f"{bm_name}.md", "w") as f:
+         f.write(md_table)
+
+def generate_comparison_plot(df, bm_name):
+    bm_df = df[df['algo_name'] == bm_name]
+    plot_cfg =  PlotConfig(hue="kernel", y="throughput_avg", x="container_cnt")
+    plot_chart(plot=plot_cfg, df=bm_df, out_fig_name=f"{bm_name}")
+
+
+def compare(df) -> str:
     benchmarks = df['algo_name'].unique()
     benchmarks.sort()
-    summary : list[str] = []
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
-        # Filter the DataFrame to only this benchmark
-        bm_summary = f"## {bm}\n\n"
-        bm_df = df[df['algo_name'] == bm]
-
-        cfg =  PlotConfig(hue="kernel", y="throughput_avg", x="container_cnt")
-        plot_chart(cfg, bm_df, f"{bm}.png")
-        create_mean_plot(bm_df, cfg, dir=".")
-
-
-        bm_summary += "|container_cnt| Kernel | Host | Type | Throughput Avg | Success Percent |\n"
-        bm_summary += "|--------|--------|------|------|----------------|----------------|\n"
-        # Add a row per configuration
-        for _, row in bm_df.iterrows():
-            bm_summary += f"|{row['container_cnt']}| {row['kernel']} | {row['hostname']} | {row['execution_type']} | {row['throughput_avg']:.2f} | {row['univ_succ_percent']:.1f} |\n"
-
-        # # Determine the best throughput
-        # max_throughput = bm_df['throughput_avg'].max()
-        # best_rows = bm_df[bm_df['throughput_avg'] == max_throughput]
-
-        # # List all rows that have the max throughput (there could be ties)
-        # best_text = ", ".join(
-        #     f"{r['kernel']}/{r['hostname']}/{r['execution_type']}" for _, r in best_rows.iterrows()
-        # )
-        # bm_summary += f"\n**Best throughput:** {max_throughput:.2f} ({best_text})\n"
-
-        # Add this benchmark summary to the list
-        summary.append(bm_summary)
-
-
-    # Join all benchmark summaries into one string
-    return "\n".join(summary)
+        generate_patch_measurement(df, bm)
+        generate_comparison_plot(df, bm)
 
 if __name__ == "__main__":
     folder = "/home/lilith/workspace/csb-analyze"
@@ -107,13 +99,9 @@ if __name__ == "__main__":
         all.extend(res)
 
     final_df =  pd.concat(all, ignore_index=True)
-
     md_table = final_df.to_markdown(index=False)
 
-    per_bm = gen_compare_summary(final_df)
-
-
-
+    per_bm = compare(final_df)
     csv  = final_df.to_csv(index=False)
     with open("results.md", "w") as f:
          f.write(md_table)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -26,13 +26,13 @@ LINEARITY_FIELD     = 'linearity' # auto-computed
 
 COMPARISON_FILED_PRETTY_NAME = {
     'Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux' : 'AMD 6.6.0',
-    'Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux': 'k920b 6.6.0'
+    'Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux': 'k920b 6.6.0',
+    'Linux localhost 7.1.0-rc1+  12 SMP PREEMPT_DYNAMIC Wed Apr 29 03:25:53 CST 2026 x86_64 x86_64 x86_64 GNU/Linux': 'AMD 7.1.0-rc1'
 }
 
 def to_pretty_name(ugly:str) -> str:
     v =  COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
     return v
-
 
 
 linearity = ""
@@ -102,10 +102,25 @@ def generate_patch_measurement(df, bm_name, env=""):
 
     # Inject improvement column between first two pretty-named columns
     if len(pretty_subjects) >= 2:
-        first, second = pretty_subjects[:2]
-        table['diff_%'] = ((table[second] - table[first]) / table[first] * 100)
-        table[second] = table[second].map(lambda x: f"{x:,.0f}")
-        table[first]  = table[first].map(lambda x: f"{x:,.0f}")
+        # First, compute improvements vs the first column (numeric!)
+        first = pretty_subjects[0]
+        for col in pretty_subjects[1:]:
+            second = col
+            # Convert columns to numeric before diff
+            first_numeric  = pd.to_numeric(table[first], errors='coerce')
+            second_numeric = pd.to_numeric(table[second], errors='coerce')
+            table[f'Improvement. ({second}) %'] = ((second_numeric - first_numeric) / first_numeric * 100).round(2)
+
+        # Then format all original subject columns with commas
+        for col in pretty_subjects:
+            table[col] = pd.to_numeric(table[col], errors='coerce').map(lambda x: f"{x:,.0f}" if pd.notna(x) else "")
+
+        # Optional: format improvement columns as percentages
+        for col in pretty_subjects[1:]:
+            diff_col = f'Improvement. ({col}) %'
+            table[diff_col] = table[diff_col].map(lambda x: f"{x:.2f} %" if pd.notna(x) else "")
+
+
 
     # Convert to Markdown and write
     md_table = table.to_markdown(index=False, tablefmt="grid")

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -4,6 +4,8 @@
 import os
 import pandas as pd
 from utils.logger import bm_log, LogType
+from bm_visualize import plot_chart, create_mean_plot
+from config.plot import PlotConfig, PlotType
 import sys
 
 # TODO: maybe it is best to compare with container count
@@ -43,31 +45,15 @@ def process(file:str) -> list:
         )
         grouped = df.groupby(group_by_fields)
         for key_group, g in grouped:
-            per_run = g.groupby('container_cnt')
-
-            avg_per_container = per_run['throughput_min'].mean()
-            min_container     = avg_per_container.index.min()
-            avg_min_throughput = float(avg_per_container[min_container])
-            linearity_per_count = avg_per_container / avg_min_throughput
-
-            dropped = linearity_per_count[(linearity_per_count < (1 - tolerance))]
-            if dropped.empty:
-                checkmark = "✔"
-                drop_note = ""
-            else:
-                checkmark = "✘"
-                drop_note = str(dropped.index.min())
+            per_run = g.groupby('container_cnt').agg(
+                throughput_avg=('throughput_min', 'mean'),
+                univ_succ_percent=('univ_succ_percent', 'mean')
+            ).reset_index()  # container_cnt becomes a column
 
 
-            record = {group_by_fields[idx]: value for idx, value in enumerate(key_group)}
-            record['linear'] = checkmark
-            record['Drops at'] = drop_note
-            record['throughput_avg'] = avg_per_container.mean()
-
-            univ_succ_avg = per_run['univ_succ_percent'].mean()  # Series of container averages
-            record['univ_succ_percent'] = univ_succ_avg.mean() # scalar average across containers
-
-            results.append(record)
+            for idx, col in enumerate(group_by_fields):
+                per_run[col] = key_group[idx]
+            results.append(per_run)
     except Exception as e:
         bm_log(f"{e} on {file}", LogType.ERROR)
 
@@ -77,29 +63,36 @@ def gen_compare_summary(df) -> str:
     benchmarks = df['algo_name'].unique()
     benchmarks.sort()
     summary : list[str] = []
+    # get all results mapped to a certain benchmark
     for bm in benchmarks:
         # Filter the DataFrame to only this benchmark
         bm_summary = f"## {bm}\n\n"
         bm_df = df[df['algo_name'] == bm]
 
-        bm_summary += "| Kernel | Host | Type | Throughput Avg | Success Percent |\n"
-        bm_summary += "|--------|------|------|----------------|----------------|\n"
+        cfg =  PlotConfig(hue="kernel", y="throughput_avg", x="container_cnt")
+        plot_chart(cfg, bm_df, f"{bm}.png")
+        create_mean_plot(bm_df, cfg, dir=".")
+
+
+        bm_summary += "|container_cnt| Kernel | Host | Type | Throughput Avg | Success Percent |\n"
+        bm_summary += "|--------|--------|------|------|----------------|----------------|\n"
         # Add a row per configuration
         for _, row in bm_df.iterrows():
-            bm_summary += f"| {row['kernel']} | {row['hostname']} | {row['execution_type']} | {row['throughput_avg']:.2f} | {row['univ_succ_percent']:.1f} |\n"
+            bm_summary += f"|{row['container_cnt']}| {row['kernel']} | {row['hostname']} | {row['execution_type']} | {row['throughput_avg']:.2f} | {row['univ_succ_percent']:.1f} |\n"
 
-        # Determine the best throughput
-        max_throughput = bm_df['throughput_avg'].max()
-        best_rows = bm_df[bm_df['throughput_avg'] == max_throughput]
+        # # Determine the best throughput
+        # max_throughput = bm_df['throughput_avg'].max()
+        # best_rows = bm_df[bm_df['throughput_avg'] == max_throughput]
 
-        # List all rows that have the max throughput (there could be ties)
-        best_text = ", ".join(
-            f"{r['kernel']}/{r['hostname']}/{r['execution_type']}" for _, r in best_rows.iterrows()
-        )
-        bm_summary += f"\n**Best throughput:** {max_throughput:.2f} ({best_text})\n"
+        # # List all rows that have the max throughput (there could be ties)
+        # best_text = ", ".join(
+        #     f"{r['kernel']}/{r['hostname']}/{r['execution_type']}" for _, r in best_rows.iterrows()
+        # )
+        # bm_summary += f"\n**Best throughput:** {max_throughput:.2f} ({best_text})\n"
 
         # Add this benchmark summary to the list
         summary.append(bm_summary)
+
 
     # Join all benchmark summaries into one string
     return "\n".join(summary)
@@ -113,9 +106,10 @@ if __name__ == "__main__":
         res = process(f)
         all.extend(res)
 
-    final_df = pd.DataFrame(all)
+    final_df =  pd.concat(all, ignore_index=True)
 
     md_table = final_df.to_markdown(index=False)
+
     per_bm = gen_compare_summary(final_df)
 
 
@@ -123,6 +117,6 @@ if __name__ == "__main__":
     csv  = final_df.to_csv(index=False)
     with open("results.md", "w") as f:
          f.write(md_table)
-         f.write(per_bm)
+        # f.write(per_bm)
     with open("results.csv", "w") as f:
          f.write(csv)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -61,8 +61,7 @@ output_dir_name = "analysis-results"
 
 
 def to_pretty_name(ugly: str) -> str:
-    v = COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
-    return v
+    return COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
 
 
 def create_output_dir() -> str:
@@ -196,7 +195,7 @@ def add_to_linearity_summary(df, bm, env, idx, tolerance=0.1) -> str:
     return summary
 
 
-def compare(df):
+def generate_comparison_reports(df):
     benchmarks = df[BENCHMARK_FIELD].unique()
     envs = df[EXEC_ENV_FIELD].unique()
     benchmarks.sort()
@@ -206,11 +205,8 @@ def compare(df):
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
         for env in envs:
-            bm_df = df[(df[BENCHMARK_FIELD] == bm) & (df["execution_type"] == env)]
-            if env == "ExecutionType.CONTAINER":
-                nice_env = "container"
-            else:
-                nice_env = "native"
+            bm_df = df[(df[BENCHMARK_FIELD] == bm) & (df[EXEC_ENV_FIELD] == env)]
+            nice_env = to_pretty_name(env)
             generate_patch_measurement(bm_df, bm, env=nice_env)
             generate_comparison_plot(
                 bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env
@@ -265,7 +261,7 @@ if __name__ == "__main__":
     final_df = pd.concat(all, ignore_index=True)
     md_table = final_df.to_markdown(index=False)
 
-    per_bm = compare(final_df)
+    per_bm = generate_comparison_reports(final_df)
     csv = final_df.to_csv(index=False)
 
     write_to_file(dir=output_dir_name, fname="results.md", content=md_table)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -10,6 +10,7 @@ from config.plot import PlotConfig, PlotType
 import sys
 from dominate import document
 from bm_utils import write_to_file, get_all_files_by_ext, read_data_frame_from_csv
+from datetime import datetime
 
 # TODO: maybe it is best to compare with container count
 # TODO: add compare to baseline
@@ -26,6 +27,13 @@ group_by_fields : list[str] = [BENCHMARK_FIELD, 'execution_type', 'hostname', 'k
 
 
 output_dir_name = "analysis-results"
+
+def create_output_dir() -> str:
+    now = datetime.now()
+    timestamp = now.strftime("%Y-%m-%d-%H-%M-%S")  # Format: YYYYMMDD_HHMMSS
+    dir = f"analysis-results-{timestamp}"
+    os.makedirs(dir, exist_ok=True)
+    return dir
 
 def process(file:str) -> list:
     tolerance = 0.1  # 10% tolerance
@@ -118,6 +126,7 @@ if __name__ == "__main__":
         help="Path(s) to folder(s) to process"
     )
     args = parser.parse_args()
+    output_dir_name = create_output_dir()
 
     # process
     files = get_files(args.folders)
@@ -133,11 +142,13 @@ if __name__ == "__main__":
     per_bm = compare(final_df)
     csv  = final_df.to_csv(index=False)
 
-    write_to_file(dir=".", fname="results.md", content=md_table)
-    write_to_file(dir=".", fname="results.csv", content=csv)
+    write_to_file(dir=output_dir_name, fname="results.md", content=md_table)
+    write_to_file(dir=output_dir_name, fname="results.csv", content=csv)
 
     doc = document()
     _add_css_style(doc)
     dump_graphs_to_doc(output_dir_name, doc)
-    write_to_file(dir=".", fname="results.html", content=doc.render())
+    write_to_file(dir=output_dir_name, fname="results.html", content=doc.render())
+    bm_log(f"Results written to {output_dir_name}", LogType.INFO)
+
 

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -4,9 +4,10 @@
 import os
 import pandas as pd
 from utils.logger import bm_log, LogType
-from bm_visualize import plot_chart, create_mean_plot
+from bm_visualize import plot_chart, dump_graphs_to_doc, create_mean_plot, _add_css_style
 from config.plot import PlotConfig, PlotType
 import sys
+from dominate import document
 
 # TODO: maybe it is best to compare with container count
 # TODO: add compare to baseline
@@ -14,6 +15,8 @@ import sys
 
 group_by_fields : list[str] = ['algo_name', 'execution_type', 'hostname', 'kernel', 'nb_threads']
 avg_fields: list[str] = ['univ_succ_percent', 'throughput_min']
+
+output_dir_name = "analysis-results"
 
 
 # collect all csvs in the given folder
@@ -60,10 +63,9 @@ def process(file:str) -> list:
     return results
 
 def generate_patch_measurement(df, bm_name):
-    bm_df = df[df['algo_name'] == bm_name]
-    subjects = bm_df['kernel'].unique()
+    subjects = df['kernel'].unique()
 
-    table = bm_df.pivot_table(
+    table = df.pivot_table(
         index='container_cnt',
         columns='kernel',
         values='throughput_avg'
@@ -72,13 +74,12 @@ def generate_patch_measurement(df, bm_name):
     table = table[['container_cnt'] + list(subjects)]
 
     md_table = table.to_markdown(index=False)
-    with open(f"{bm_name}.md", "w") as f:
+    with open(f"{output_dir_name}/{bm_name}.md", "w") as f:
          f.write(md_table)
 
 def generate_comparison_plot(df, bm_name):
-    bm_df = df[df['algo_name'] == bm_name]
     plot_cfg =  PlotConfig(hue="kernel", y="throughput_avg", x="container_cnt")
-    plot_chart(plot=plot_cfg, df=bm_df, out_fig_name=f"{bm_name}")
+    plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}")
 
 
 def compare(df) -> str:
@@ -86,8 +87,10 @@ def compare(df) -> str:
     benchmarks.sort()
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
-        generate_patch_measurement(df, bm)
-        generate_comparison_plot(df, bm)
+        bm_df = df[(df['algo_name'] == bm) &
+                   (df['execution_type'] == 'ExecutionType.CONTAINER')]
+        generate_patch_measurement(bm_df, bm)
+        generate_comparison_plot(bm_df, bm)
 
 if __name__ == "__main__":
     folder = "/home/lilith/workspace/csb-analyze"
@@ -108,3 +111,9 @@ if __name__ == "__main__":
         # f.write(per_bm)
     with open("results.csv", "w") as f:
          f.write(csv)
+
+    doc = document()
+    _add_css_style(doc)
+    dump_graphs_to_doc(output_dir_name, doc)
+    with open("results.html", "w") as f:
+        f.write(doc.render())

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -39,6 +39,12 @@ def get_all_files_by_ext(dir:str, extension:str = ".csv"):
 # algo_name
 # execution_type // group by
 
+def write_to_file(content, fname, dir):
+    os.makedirs(dir, exist_ok=True)
+    file_path = os.path.join(dir, fname)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
 def process(file:str) -> list:
     tolerance = 0.1  # 10% tolerance
     results = []
@@ -64,7 +70,6 @@ def process(file:str) -> list:
 
 def generate_patch_measurement(df, bm_name):
     subjects = df['kernel'].unique()
-
     table = df.pivot_table(
         index='container_cnt',
         columns='kernel',
@@ -72,13 +77,21 @@ def generate_patch_measurement(df, bm_name):
     ).reset_index()
 
     table = table[['container_cnt'] + list(subjects)]
-
     md_table = table.to_markdown(index=False)
-    with open(f"{output_dir_name}/{bm_name}.md", "w") as f:
-         f.write(md_table)
+
+    md_info  = f"# {bm_name}\n"
+
+    write_to_file(dir=output_dir_name, fname=f"{bm_name}.md", content=md_info + md_table)
 
 def generate_comparison_plot(df, bm_name):
-    plot_cfg =  PlotConfig(hue="kernel", y="throughput_avg", x="container_cnt")
+    plot_cfg =  PlotConfig(
+        hue="kernel",
+        hue_lbl="Kernel",
+        y="throughput_avg",
+        y_lbl="Throughput Average",
+        x="container_cnt",
+        x_lbl="#Executions Units",
+    )
     plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}")
 
 
@@ -106,14 +119,12 @@ if __name__ == "__main__":
 
     per_bm = compare(final_df)
     csv  = final_df.to_csv(index=False)
-    with open("results.md", "w") as f:
-         f.write(md_table)
-        # f.write(per_bm)
-    with open("results.csv", "w") as f:
-         f.write(csv)
+
+    write_to_file(dir=".", fname="results.md", content=md_table)
+    write_to_file(dir=".", fname="results.csv", content=csv)
 
     doc = document()
     _add_css_style(doc)
     dump_graphs_to_doc(output_dir_name, doc)
-    with open("results.html", "w") as f:
-        f.write(doc.render())
+    write_to_file(dir=".", fname="results.html", content=doc.render())
+

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -12,6 +12,19 @@ from dominate import document
 from bm_utils import write_to_file, get_all_files_by_ext, read_data_frame_from_csv
 from datetime import datetime
 
+################################################################################################
+# Input: directories
+# Output: directory with many files
+#   - <benchmark-name>.txt - a text table comparing the benchmark throughput on different kernels
+#   - <benchmark-name>*.png - a png plot comparing the benchmark on different kernels
+#   - results.html - all comparison plots in one file
+#   - results.csv  - all results in one csv
+#   - results.md   - all results in one md
+#
+# Process: The script looks for available CSV recursively in all given directories
+#       the CSVs are expected to comply with the default output CSV of CSB
+#       The subject of comparison is the kernel
+################################################################################################
 
 
 BENCHMARK_FIELD     = 'algo_name'

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -12,7 +12,7 @@ from dominate import document
 from bm_utils import write_to_file, get_all_files_by_ext, read_data_frame_from_csv
 from datetime import datetime
 
-# TODO: maybe it is best to compare with container count
+
 # TODO: add compare to baseline
 # TODO: generate in linux fashion
 
@@ -20,10 +20,13 @@ BENCHMARK_FIELD     = 'algo_name'
 THROUGHPUT_FIELD    = 'throughput_min'
 COUNT_FIELD         = 'container_cnt'
 SUCCESS_FIELD       = 'univ_succ_percent'
-LINEARITY_FIELD     = 'linearity'
+COMPARISON_FIELD    = 'kernel'
+MEASUREMENT_FIELD   = 'throughput_avg' # auto-computed
+LINEARITY_FIELD     = 'linearity' # auto-computed
 
 
-group_by_fields : list[str] = [BENCHMARK_FIELD, 'execution_type', 'hostname', 'kernel', 'nb_threads']
+
+group_by_fields : list[str] = [BENCHMARK_FIELD, 'execution_type', 'hostname', COMPARISON_FIELD, 'nb_threads']
 
 
 output_dir_name = "analysis-results"
@@ -54,20 +57,20 @@ def process(file:str) -> list:
             per_run[col] = key_group[idx]
 
         min_container = per_run[COUNT_FIELD].min()
-        baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, 'throughput_avg'].iloc[0]
+        baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, MEASUREMENT_FIELD].iloc[0]
 
-        per_run[LINEARITY_FIELD] = per_run['throughput_avg']/baseline
+        per_run[LINEARITY_FIELD] = per_run[MEASUREMENT_FIELD]/baseline
         results.append(per_run)
 
 
     return results
 
 def generate_patch_measurement(df, bm_name):
-    subjects = df['kernel'].unique()
+    subjects = df[COMPARISON_FIELD].unique()
     table = df.pivot_table(
         index=COUNT_FIELD,
-        columns='kernel',
-        values='throughput_avg'
+        columns=COMPARISON_FIELD,
+        values=MEASUREMENT_FIELD
     ).reset_index()
 
     table = table[[COUNT_FIELD] + list(subjects)]
@@ -85,8 +88,9 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity'):
         y_lbl=y_lbl,
         x=COUNT_FIELD,
         x_lbl="#Executions Units",
+        title=bm_name,
     )
-    plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}")
+    plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}-{y_lbl}")
 
 
 def compare(df) -> str:
@@ -97,7 +101,7 @@ def compare(df) -> str:
         bm_df = df[(df[BENCHMARK_FIELD] == bm) &
                    (df['execution_type'] == 'ExecutionType.CONTAINER')]
         generate_patch_measurement(bm_df, bm)
-        generate_comparison_plot(bm_df, bm, y="throughput_avg", y_lbl="Throughput Average")
+        generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average")
         generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)")
         generate_comparison_plot(bm_df, bm)
 

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -62,6 +62,11 @@ def process(file:str) -> list:
 
             for idx, col in enumerate(group_by_fields):
                 per_run[col] = key_group[idx]
+
+            min_container = per_run['container_cnt'].min()
+            baseline = per_run.loc[per_run['container_cnt'] == min_container, 'throughput_avg'].iloc[0]
+
+            per_run['linearity'] = per_run['throughput_avg']/baseline
             results.append(per_run)
     except Exception as e:
         bm_log(f"{e} on {file}", LogType.ERROR)
@@ -83,12 +88,12 @@ def generate_patch_measurement(df, bm_name):
 
     write_to_file(dir=output_dir_name, fname=f"{bm_name}.md", content=md_info + md_table)
 
-def generate_comparison_plot(df, bm_name):
+def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity'):
     plot_cfg =  PlotConfig(
         hue="kernel",
         hue_lbl="Kernel",
-        y="throughput_avg",
-        y_lbl="Throughput Average",
+        y=y,
+        y_lbl=y_lbl,
         x="container_cnt",
         x_lbl="#Executions Units",
     )
@@ -103,6 +108,8 @@ def compare(df) -> str:
         bm_df = df[(df['algo_name'] == bm) &
                    (df['execution_type'] == 'ExecutionType.CONTAINER')]
         generate_patch_measurement(bm_df, bm)
+        generate_comparison_plot(bm_df, bm, y="throughput_avg", y_lbl="Throughput Average")
+        generate_comparison_plot(bm_df, bm, y="univ_succ_percent", y_lbl="Success Average (%)")
         generate_comparison_plot(bm_df, bm)
 
 if __name__ == "__main__":

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -2,86 +2,67 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 import os
+import argparse
 import pandas as pd
 from utils.logger import bm_log, LogType
 from bm_visualize import plot_chart, dump_graphs_to_doc, create_mean_plot, _add_css_style
 from config.plot import PlotConfig, PlotType
 import sys
 from dominate import document
+from bm_utils import write_to_file, get_all_files_by_ext, read_data_frame_from_csv
 
 # TODO: maybe it is best to compare with container count
 # TODO: add compare to baseline
 # TODO: generate in linux fashion
 
-group_by_fields : list[str] = ['algo_name', 'execution_type', 'hostname', 'kernel', 'nb_threads']
-avg_fields: list[str] = ['univ_succ_percent', 'throughput_min']
+BENCHMARK_FIELD     = 'algo_name'
+THROUGHPUT_FIELD    = 'throughput_min'
+COUNT_FIELD         = 'container_cnt'
+SUCCESS_FIELD       = 'univ_succ_percent'
+LINEARITY_FIELD     = 'linearity'
+
+
+group_by_fields : list[str] = [BENCHMARK_FIELD, 'execution_type', 'hostname', 'kernel', 'nb_threads']
+
 
 output_dir_name = "analysis-results"
-
-
-# collect all csvs in the given folder
-def get_all_files_by_ext(dir:str, extension:str = ".csv"):
-    """
-    Returns all files under the given dir and subdirs, which have the given file extension.
-    """
-    filtered_files = []
-    for root, _, files  in os.walk(dir):
-        for file in files:
-            if file.endswith(extension):
-                abs_path = os.path.join(root, file)
-                filtered_files.append(abs_path)
-    return filtered_files
-
-# Allowed CPUs
-# kernel
-# throughput_min  // avg
-# univ_succ_percent
-# algo_name
-# execution_type // group by
-
-def write_to_file(content, fname, dir):
-    os.makedirs(dir, exist_ok=True)
-    file_path = os.path.join(dir, fname)
-    with open(file_path, "w", encoding="utf-8") as f:
-        f.write(content)
 
 def process(file:str) -> list:
     tolerance = 0.1  # 10% tolerance
     results = []
-    try:
-        df = pd.read_csv(
-            file, sep=";", comment="#", engine="python", on_bad_lines="error"
-        )
-        grouped = df.groupby(group_by_fields)
-        for key_group, g in grouped:
-            per_run = g.groupby('container_cnt').agg(
-                throughput_avg=('throughput_min', 'mean'),
-                univ_succ_percent=('univ_succ_percent', 'mean')
-            ).reset_index()  # container_cnt becomes a column
+    df = read_data_frame_from_csv(file)
+    if df is None:
+        return []
+
+    grouped = df.groupby(group_by_fields)
+    for key_group, g in grouped:
+        per_run = g.groupby(COUNT_FIELD).agg(
+            throughput_avg=(THROUGHPUT_FIELD, 'mean'),
+            success_avg=(SUCCESS_FIELD, 'mean')
+        ).reset_index()  # container_cnt becomes a column
 
 
-            for idx, col in enumerate(group_by_fields):
-                per_run[col] = key_group[idx]
+        for idx, col in enumerate(group_by_fields):
+            per_run[col] = key_group[idx]
 
-            min_container = per_run['container_cnt'].min()
-            baseline = per_run.loc[per_run['container_cnt'] == min_container, 'throughput_avg'].iloc[0]
+        min_container = per_run[COUNT_FIELD].min()
+        baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, 'throughput_avg'].iloc[0]
 
-            per_run['linearity'] = per_run['throughput_avg']/baseline
-            results.append(per_run)
-    except Exception as e:
-        bm_log(f"{e} on {file}", LogType.ERROR)
+        per_run[LINEARITY_FIELD] = per_run['throughput_avg']/baseline
+        results.append(per_run)
+
 
     return results
 
 def generate_patch_measurement(df, bm_name):
     subjects = df['kernel'].unique()
     table = df.pivot_table(
-        index='container_cnt',
+        index=COUNT_FIELD,
         columns='kernel',
         values='throughput_avg'
     ).reset_index()
 
-    table = table[['container_cnt'] + list(subjects)]
+    table = table[[COUNT_FIELD] + list(subjects)]
     md_table = table.to_markdown(index=False)
 
     md_info  = f"# {bm_name}\n"
@@ -94,28 +75,53 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity'):
         hue_lbl="Kernel",
         y=y,
         y_lbl=y_lbl,
-        x="container_cnt",
+        x=COUNT_FIELD,
         x_lbl="#Executions Units",
     )
     plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}")
 
 
 def compare(df) -> str:
-    benchmarks = df['algo_name'].unique()
+    benchmarks = df[BENCHMARK_FIELD].unique()
     benchmarks.sort()
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
-        bm_df = df[(df['algo_name'] == bm) &
+        bm_df = df[(df[BENCHMARK_FIELD] == bm) &
                    (df['execution_type'] == 'ExecutionType.CONTAINER')]
         generate_patch_measurement(bm_df, bm)
         generate_comparison_plot(bm_df, bm, y="throughput_avg", y_lbl="Throughput Average")
-        generate_comparison_plot(bm_df, bm, y="univ_succ_percent", y_lbl="Success Average (%)")
+        generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)")
         generate_comparison_plot(bm_df, bm)
 
+
+def get_files(folders):
+    all_files = []
+    for folder in folders:
+        if not os.path.isdir(folder):
+            bm_log(f"Skipping {folder}. It is not a valid directory.", LogType.ERROR)
+            continue
+        files = get_all_files_by_ext(folder)
+        bm_log(f"Found {len(files)} CSV in {folder}.")
+        all_files.extend(files)
+    return all_files
+
+
 if __name__ == "__main__":
-    folder = "/home/lilith/workspace/csb-analyze"
-    files = get_all_files_by_ext(folder)
-    bm_log(f"Running analysis on {folder}. {len(files)} CSV files detected ...", LogType.INFO)
+    """
+    """
+    parser = argparse.ArgumentParser(
+        description="Process one or more folders."
+    )
+    parser.add_argument(
+        "folders",
+        nargs="+",  # One or more arguments
+        help="Path(s) to folder(s) to process"
+    )
+    args = parser.parse_args()
+
+    # process
+    files = get_files(args.folders)
+    bm_log(f"Processing {len(files)} files", LogType.INFO)
     all = []
     for f in files:
         res = process(f)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
 import os
 import pandas as pd
+from utils.logger import bm_log, LogType
+import sys
+
+group_by_fields : list[str] = ['algo_name', 'execution_type', 'hostname', 'kernel', 'nb_threads']
+avg_fields: list[str] = ['univ_succ_percent', 'throughput_min']
+
 
 # collect all csvs in the given folder
-def find_csvs(folder_path:str):
-    csvs = []
-    for root, dirs, files  in os.walk(folder_path):
+def get_all_files_by_ext(dir:str, extension:str = ".csv"):
+    """
+    Returns all files under the given dir and subdirs, which have the given file extension.
+    """
+    filtered_files = []
+    for root, _, files  in os.walk(dir):
         for file in files:
-            if file.endswith(".csv"):
-                file_path = os.path.join(root, file)
-                csvs.append(file_path)
-    return csvs
+            if file.endswith(extension):
+                abs_path = os.path.join(root, file)
+                filtered_files.append(abs_path)
+    return filtered_files
 
 # Allowed CPUs
 # kernel
@@ -26,13 +35,13 @@ def process(file:str) -> list:
         df = pd.read_csv(
             file, sep=";", comment="#", engine="python", on_bad_lines="error"
         )
-        grouped = df.groupby(['algo_name', 'execution_type', 'kernel', 'nb_threads'])
-        for key, g in grouped:
-            algo_name, execution_type, kernel, num_threads = key
+        grouped = df.groupby(group_by_fields)
+        for key_group, g in grouped:
+            per_run = g.groupby('container_cnt')
 
-            avg_per_container = g.groupby('container_cnt')['throughput_min'].mean()
+            avg_per_container = per_run['throughput_min'].mean()
             min_container     = avg_per_container.index.min()
-            avg_min_throughput = avg_per_container[min_container]
+            avg_min_throughput = float(avg_per_container[min_container])
             linearity_per_count = avg_per_container / avg_min_throughput
 
             dropped = linearity_per_count[(linearity_per_count < (1 - tolerance))]
@@ -43,23 +52,25 @@ def process(file:str) -> list:
                 checkmark = "✘"
                 drop_note = str(dropped.index.min())
 
-            results.append({
-                'Benchmark': algo_name,
-                'Execution Unit': execution_type,
-                'Kernel': kernel,
-                'Number of Threads': num_threads,
-                'linear': checkmark,
-                'Drops at': drop_note
-            })
 
-        return results
+            record = {group_by_fields[idx]: value for idx, value in enumerate(key_group)}
+            record['linear'] = checkmark
+            record['Drops at'] = drop_note
+            record['throughput_avg'] = avg_per_container.mean()
+
+            univ_succ_avg = per_run['univ_succ_percent'].mean()  # Series of container averages
+            record['univ_succ_percent'] = univ_succ_avg.mean() # scalar average across containers
+
+            results.append(record)
     except Exception as e:
-        print(f"{e} on {file}")
-        return results
+        bm_log(f"{e} on {file}", LogType.ERROR)
+
+    return results
 
 if __name__ == "__main__":
     folder = "/home/lilith/workspace/csb-analyze"
-    files = find_csvs(folder)
+    files = get_all_files_by_ext(folder)
+    bm_log(f"Running analysis on {folder}. {len(files)} CSV files detected ...", LogType.INFO)
     all = []
     for f in files:
         res = process(f)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -26,6 +26,7 @@ MEASUREMENT_FIELD   = 'throughput_avg' # auto-computed
 LINEARITY_FIELD     = 'linearity' # auto-computed
 
 
+linearity = ""
 
 group_by_fields : list[str] = [BENCHMARK_FIELD, EXEC_ENV_FIELD, 'hostname', COMPARISON_FIELD, 'nb_threads']
 
@@ -53,11 +54,11 @@ def process(file:str) -> list:
             success_avg=(SUCCESS_FIELD, 'mean')
         ).reset_index()  # container_cnt becomes a column
 
-
         for idx, col in enumerate(group_by_fields):
             per_run[col] = key_group[idx]
 
         min_container = per_run[COUNT_FIELD].min()
+        assert 'throughput_avg' == MEASUREMENT_FIELD
         baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, MEASUREMENT_FIELD].iloc[0]
 
         per_run[LINEARITY_FIELD] = per_run[MEASUREMENT_FIELD]/baseline
@@ -95,6 +96,38 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', env=
     plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}-{env}-{y_lbl}")
 
 
+def add_to_linearity_summary(df, bm, env, tolerance=0.1) -> str:
+    """
+    Summarize linearity of a benchmark across kernels.
+
+    Args:
+        df: DataFrame containing at least COUNT_FIELD, COMPARISON_FIELD, LINEARITY_FIELD
+        bm: Benchmark name
+        env: Execution environment
+        tolerance: Allowed deviation from perfect linearity (1.0)
+
+    Returns:
+        A one-line summary string.
+    """
+    summary_parts = []
+
+    for kernel, g in df.groupby(COMPARISON_FIELD):
+        g_sorted = g.sort_values(COUNT_FIELD)
+        baseline = g_sorted[LINEARITY_FIELD].iloc[0]
+        drops = g_sorted[g_sorted[LINEARITY_FIELD] < 1 - tolerance]
+
+        if drops.empty:
+            summary_parts.append(f"{kernel}: linear")
+        else:
+            first_drop_cnt = drops[COUNT_FIELD].iloc[0]
+            first_drop_val = drops[LINEARITY_FIELD].iloc[0]
+            summary_parts.append(
+                f"{kernel}: drops at {COUNT_FIELD}={first_drop_cnt} (linearity={first_drop_val:.2f})"
+            )
+
+    print(f"{bm} ({env}) -> " + "\n ".join(summary_parts))
+
+
 def compare(df) -> str:
     benchmarks = df[BENCHMARK_FIELD].unique()
     envs = df[EXEC_ENV_FIELD].unique()
@@ -112,7 +145,7 @@ def compare(df) -> str:
             generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env)
             generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)", env=nice_env)
             generate_comparison_plot(bm_df, bm, env=nice_env)
-
+            add_to_linearity_summary(bm_df, bm, env=nice_env, tolerance=0.1)
 
 def get_files(folders):
     all_files = []

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -13,8 +13,6 @@ from bm_utils import write_to_file, get_all_files_by_ext, read_data_frame_from_c
 from datetime import datetime
 
 
-# TODO: add compare to baseline
-# TODO: generate in linux fashion
 
 BENCHMARK_FIELD     = 'algo_name'
 THROUGHPUT_FIELD    = 'throughput_min'
@@ -116,15 +114,15 @@ def generate_patch_measurement(df, bm_name, env=""):
 
     write_to_file(dir=output_dir_name, fname=f"{bm_name}-{env}.txt", content=md_info + md_table)
 
-def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', env=""):
+def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', plot_type=PlotType.NORMAL, env=""):
     plot_cfg =  PlotConfig(
-        hue="kernel",
-        hue_lbl="Kernel",
+        hue=COMPARISON_FIELD,
         y=y,
         y_lbl=y_lbl,
         x=COUNT_FIELD,
         x_lbl="#Executions Units",
         title=f"{bm_name}({env})",
+        type=plot_type,
     )
     plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}-{env}-{y_lbl}")
 
@@ -154,6 +152,7 @@ def compare(df) -> str:
     benchmarks = df[BENCHMARK_FIELD].unique()
     envs = df[EXEC_ENV_FIELD].unique()
     benchmarks.sort()
+    df[COMPARISON_FIELD] = df[COMPARISON_FIELD].map(lambda x: f"{to_pretty_name(x)}")
     Linearity_md = "# Linearity Summary\n"
     idx = 1
     # get all results mapped to a certain benchmark
@@ -167,7 +166,7 @@ def compare(df) -> str:
                 nice_env = "native"
             generate_patch_measurement(bm_df, bm, env=nice_env)
             generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env)
-            generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)", env=nice_env)
+            generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)", env=nice_env, plot_type=PlotType.SUCCESS_PERCENT)
             generate_comparison_plot(bm_df, bm, env=nice_env)
             Linearity_md+=add_to_linearity_summary(bm_df, bm, env=nice_env, idx=idx, tolerance=0.1)
         idx+=1
@@ -219,7 +218,7 @@ if __name__ == "__main__":
 
     doc = document()
     _add_css_style(doc)
-    dump_graphs_to_doc(output_dir_name, doc)
+    dump_graphs_to_doc(output_dir_name, doc, num_plot_in_row=3)
     write_to_file(dir=output_dir_name, fname="results.html", content=doc.render())
     bm_log(f"Results written to {output_dir_name}", LogType.INFO)
 

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -27,7 +27,7 @@ LINEARITY_FIELD     = 'linearity' # auto-computed
 
 
 COMPARISON_FILED_PRETTY_NAME = {
-    'Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux' : 'AMD 6.6.0 138',
+    'Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux' : 'AMD 6.6.0',
     'Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux': 'k920b 6.6.0'
 }
 
@@ -130,18 +130,6 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', env=
 
 
 def add_to_linearity_summary(df, bm, env, idx, tolerance=0.1) -> str:
-    """
-    Summarize linearity of a benchmark across kernels.
-
-    Args:
-        df: DataFrame containing at least COUNT_FIELD, COMPARISON_FIELD, LINEARITY_FIELD
-        bm: Benchmark name
-        env: Execution environment
-        tolerance: Allowed deviation from perfect linearity (1.0)
-
-    Returns:
-        A one-line summary string.
-    """
     summary = f"## {idx}. {bm} ({env})\n"
     summary += f"|{COMPARISON_FIELD} | Linear | Drops at|\n"
     summary += f"|--- |--- |---|\n"
@@ -150,7 +138,7 @@ def add_to_linearity_summary(df, bm, env, idx, tolerance=0.1) -> str:
         g_sorted = g.sort_values(COUNT_FIELD)
         baseline = g_sorted[LINEARITY_FIELD].iloc[0]
         drops = g_sorted[g_sorted[LINEARITY_FIELD] < 1 - tolerance]
-        summary += f'|{kernel}|'
+        summary += f'|{to_pretty_name(kernel)}|'
 
         if drops.empty:
             summary += f'✔️|-|\n'

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -40,7 +40,10 @@ LINEARITY_FIELD     = 'linearity' # auto-computed
 COMPARISON_FILED_PRETTY_NAME = {
     'Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux' : 'AMD 6.6.0',
     'Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux': 'k920b 6.6.0',
-    'Linux localhost 7.1.0-rc1+  12 SMP PREEMPT_DYNAMIC Wed Apr 29 03:25:53 CST 2026 x86_64 x86_64 x86_64 GNU/Linux': 'AMD 7.1.0-rc1'
+    'Linux localhost 7.1.0-rc1+  12 SMP PREEMPT_DYNAMIC Wed Apr 29 03:25:53 CST 2026 x86_64 x86_64 x86_64 GNU/Linux': 'AMD 7.1.0-rc1',
+    'ExecutionType.CONTAINER': 'container',
+    'ExecutionType.NATIVE': 'native',
+    'container_cnt' : '#Instances'
 }
 
 def to_pretty_name(ugly:str) -> str:
@@ -53,6 +56,7 @@ linearity = ""
 group_by_fields : list[str] = [BENCHMARK_FIELD, EXEC_ENV_FIELD, 'hostname', COMPARISON_FIELD, 'nb_threads']
 
 
+# this is a global variable that will be overwritten
 output_dir_name = "analysis-results"
 
 def create_output_dir() -> str:
@@ -62,11 +66,36 @@ def create_output_dir() -> str:
     os.makedirs(dir, exist_ok=True)
     return dir
 
-def process(file:str) -> list:
-    tolerance = 0.1  # 10% tolerance
+def transform(file:str) -> list:
+    """
+    Processes a CSV file to compute per-run metrics.
+
+    Steps:
+    1. Reads the CSV into a DataFrame.
+    2. Groups by `group_by_fields`.
+    3. Aggregates throughput and success percent by mean per `COUNT_FIELD`.
+    4. Computes linearity relative to the minimum count of containers.
+
+    Parameters
+    ----------
+    file : str
+        Path to the CSV file to process.
+
+    Returns
+    -------
+    results : list of pd.DataFrame
+        Each element corresponds to a group defined by `group_by_fields`,
+        containing:
+            - COUNT_FIELD column (e.g., container count)
+            - throughput_avg (mean throughput)
+            - success_avg (mean success %)
+            - linearity relative to minimum container count
+    """
     results = []
+    # read the csv file as a dataframe
     df = read_data_frame_from_csv(file)
     if df is None:
+        # there has been an error
         return []
 
     grouped = df.groupby(group_by_fields)
@@ -81,19 +110,16 @@ def process(file:str) -> list:
 
         min_container = per_run[COUNT_FIELD].min()
         assert 'throughput_avg' == MEASUREMENT_FIELD
-        baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, MEASUREMENT_FIELD].iloc[0]
 
+        # baseline is the throughput associated with the minimum count of containers (usually 1)
+        baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, MEASUREMENT_FIELD].iloc[0]
+        # calc linearity
         per_run[LINEARITY_FIELD] = per_run[MEASUREMENT_FIELD]/baseline
         results.append(per_run)
-
-
     return results
 
 def generate_patch_measurement(df, bm_name, env=""):
     subjects = df[COMPARISON_FIELD].unique()
-
-    # Map original subjects to pretty names
-    pretty_mapping = {s: to_pretty_name(s) for s in subjects}
 
     # Pivot table
     table = df.pivot_table(
@@ -106,18 +132,15 @@ def generate_patch_measurement(df, bm_name, env=""):
     if isinstance(table.columns, pd.MultiIndex):
         table.columns = [col[1] if col[1] else col[0] for col in table.columns]
 
-    # Rename columns to pretty names immediately
-    table.rename(columns=pretty_mapping, inplace=True)
 
-    # Keep COUNT_FIELD + pretty columns
-    pretty_subjects = [pretty_mapping[s] for s in subjects]
-    table = table[[COUNT_FIELD] + pretty_subjects]
+    # Keep COUNT_FIELD
+    #table = table[[COUNT_FIELD] + subjects]
 
     # Inject improvement column between first two pretty-named columns
-    if len(pretty_subjects) >= 2:
+    if len(subjects) >= 2:
         # First, compute improvements vs the first column (numeric!)
-        first = pretty_subjects[0]
-        for col in pretty_subjects[1:]:
+        first = subjects[0]
+        for col in subjects[1:]:
             second = col
             # Convert columns to numeric before diff
             first_numeric  = pd.to_numeric(table[first], errors='coerce')
@@ -125,11 +148,11 @@ def generate_patch_measurement(df, bm_name, env=""):
             table[f'Improvement. ({second}) %'] = ((second_numeric - first_numeric) / first_numeric * 100).round(2)
 
         # Then format all original subject columns with commas
-        for col in pretty_subjects:
+        for col in subjects:
             table[col] = pd.to_numeric(table[col], errors='coerce').map(lambda x: f"{x:,.0f}" if pd.notna(x) else "")
 
         # Optional: format improvement columns as percentages
-        for col in pretty_subjects[1:]:
+        for col in subjects[1:]:
             diff_col = f'Improvement. ({col}) %'
             table[diff_col] = table[diff_col].map(lambda x: f"{x:.2f} %" if pd.notna(x) else "")
 
@@ -201,14 +224,14 @@ def compare(df) -> str:
 
     write_to_file(Linearity_md, "linearity.md", output_dir_name)
 
-def get_files(folders):
+def get_all_csvs(dirs:list[str]):
     all_files = []
-    for folder in folders:
-        if not os.path.isdir(folder):
-            bm_log(f"Skipping {folder}. It is not a valid directory.", LogType.ERROR)
+    for dir in dirs:
+        if not os.path.isdir(dir):
+            bm_log(f"Skipping {dir}. It is not a valid directory.", LogType.ERROR)
             continue
-        files = get_all_files_by_ext(folder)
-        bm_log(f"Found {len(files)} CSV in {folder}.")
+        files = get_all_files_by_ext(dir=dir, extension=".csv")
+        bm_log(f"Found {len(files)} CSV in {dir}.")
         all_files.extend(files)
     return all_files
 
@@ -228,11 +251,11 @@ if __name__ == "__main__":
     output_dir_name = create_output_dir()
 
     # process
-    files = get_files(args.folders)
+    files = get_all_csvs(args.folders)
     bm_log(f"Processing {len(files)} files", LogType.INFO)
     all = []
     for f in files:
-        res = process(f)
+        res = transform(f)
         all.extend(res)
 
     final_df =  pd.concat(all, ignore_index=True)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -58,7 +58,7 @@ def process(file:str) -> list:
         return results
 
 if __name__ == "__main__":
-    folder = "/home/lilith/workspace/csb-analyze/results"
+    folder = "/home/lilith/workspace/csb-analyze"
     files = find_csvs(folder)
     all = []
     for f in files:

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
 import os
 import pandas as pd
 from utils.logger import bm_log, LogType

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -4,6 +4,10 @@ import pandas as pd
 from utils.logger import bm_log, LogType
 import sys
 
+# TODO: maybe it is best to compare with container count
+# TODO: add compare to baseline
+# TODO: generate in linux fashion
+
 group_by_fields : list[str] = ['algo_name', 'execution_type', 'hostname', 'kernel', 'nb_threads']
 avg_fields: list[str] = ['univ_succ_percent', 'throughput_min']
 

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -67,6 +67,37 @@ def process(file:str) -> list:
 
     return results
 
+def gen_compare_summary(df) -> str:
+    benchmarks = df['algo_name'].unique()
+    benchmarks.sort()
+    summary : list[str] = []
+    for bm in benchmarks:
+        # Filter the DataFrame to only this benchmark
+        bm_summary = f"## {bm}\n\n"
+        bm_df = df[df['algo_name'] == bm]
+
+        bm_summary += "| Kernel | Host | Type | Throughput Avg | Success Percent |\n"
+        bm_summary += "|--------|------|------|----------------|----------------|\n"
+        # Add a row per configuration
+        for _, row in bm_df.iterrows():
+            bm_summary += f"| {row['kernel']} | {row['hostname']} | {row['execution_type']} | {row['throughput_avg']:.2f} | {row['univ_succ_percent']:.1f} |\n"
+
+        # Determine the best throughput
+        max_throughput = bm_df['throughput_avg'].max()
+        best_rows = bm_df[bm_df['throughput_avg'] == max_throughput]
+
+        # List all rows that have the max throughput (there could be ties)
+        best_text = ", ".join(
+            f"{r['kernel']}/{r['hostname']}/{r['execution_type']}" for _, r in best_rows.iterrows()
+        )
+        bm_summary += f"\n**Best throughput:** {max_throughput:.2f} ({best_text})\n"
+
+        # Add this benchmark summary to the list
+        summary.append(bm_summary)
+
+    # Join all benchmark summaries into one string
+    return "\n".join(summary)
+
 if __name__ == "__main__":
     folder = "/home/lilith/workspace/csb-analyze"
     files = get_all_files_by_ext(folder)
@@ -77,9 +108,15 @@ if __name__ == "__main__":
         all.extend(res)
 
     final_df = pd.DataFrame(all)
+
     md_table = final_df.to_markdown(index=False)
+    per_bm = gen_compare_summary(final_df)
+
+
+
     csv  = final_df.to_csv(index=False)
     with open("results.md", "w") as f:
          f.write(md_table)
+         f.write(per_bm)
     with open("results.csv", "w") as f:
          f.write(csv)

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -132,18 +132,13 @@ def generate_patch_measurement(df, bm_name, env=""):
     if isinstance(table.columns, pd.MultiIndex):
         table.columns = [col[1] if col[1] else col[0] for col in table.columns]
 
-
-    # Keep COUNT_FIELD
-    #table = table[[COUNT_FIELD] + subjects]
-
     # Inject improvement column between first two pretty-named columns
     if len(subjects) >= 2:
         # First, compute improvements vs the first column (numeric!)
         first = subjects[0]
+        first_numeric  = pd.to_numeric(table[first], errors='coerce')
         for col in subjects[1:]:
             second = col
-            # Convert columns to numeric before diff
-            first_numeric  = pd.to_numeric(table[first], errors='coerce')
             second_numeric = pd.to_numeric(table[second], errors='coerce')
             table[f'Improvement. ({second}) %'] = ((second_numeric - first_numeric) / first_numeric * 100).round(2)
 
@@ -151,13 +146,8 @@ def generate_patch_measurement(df, bm_name, env=""):
         for col in subjects:
             table[col] = pd.to_numeric(table[col], errors='coerce').map(lambda x: f"{x:,.0f}" if pd.notna(x) else "")
 
-        # Optional: format improvement columns as percentages
-        for col in subjects[1:]:
-            diff_col = f'Improvement. ({col}) %'
-            table[diff_col] = table[diff_col].map(lambda x: f"{x:.2f} %" if pd.notna(x) else "")
 
-
-
+    table.rename(columns={COUNT_FIELD: to_pretty_name(COUNT_FIELD)}, inplace=True)
     # Convert to Markdown and write
     md_table = table.to_markdown(index=False, tablefmt="grid")
     md_info  = f"- {bm_name}\n"

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -5,9 +5,8 @@ import os
 import argparse
 import pandas as pd
 from utils.logger import bm_log, LogType
-from bm_visualize import plot_chart, dump_graphs_to_doc, create_mean_plot, _add_css_style
+from bm_visualize import plot_chart, dump_graphs_to_doc, _add_css_style
 from config.plot import PlotConfig, PlotType
-import sys
 from dominate import document
 from bm_utils import write_to_file, get_all_files_by_ext, read_data_frame_from_csv
 from datetime import datetime
@@ -27,37 +26,44 @@ from datetime import datetime
 ################################################################################################
 
 
-BENCHMARK_FIELD     = 'algo_name'
-THROUGHPUT_FIELD    = 'throughput_min'
-COUNT_FIELD         = 'container_cnt'
-SUCCESS_FIELD       = 'univ_succ_percent'
-COMPARISON_FIELD    = 'kernel'
-EXEC_ENV_FIELD      = 'execution_type'
-MEASUREMENT_FIELD   = 'throughput_avg' # auto-computed
-LINEARITY_FIELD     = 'linearity' # auto-computed
+BENCHMARK_FIELD = "algo_name"
+THROUGHPUT_FIELD = "throughput_min"
+COUNT_FIELD = "container_cnt"
+SUCCESS_FIELD = "univ_succ_percent"
+COMPARISON_FIELD = "kernel"
+EXEC_ENV_FIELD = "execution_type"
+MEASUREMENT_FIELD = "throughput_avg"  # auto-computed
+LINEARITY_FIELD = "linearity"  # auto-computed
 
 
 COMPARISON_FILED_PRETTY_NAME = {
-    'Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux' : 'AMD 6.6.0',
-    'Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux': 'k920b 6.6.0',
-    'Linux localhost 7.1.0-rc1+  12 SMP PREEMPT_DYNAMIC Wed Apr 29 03:25:53 CST 2026 x86_64 x86_64 x86_64 GNU/Linux': 'AMD 7.1.0-rc1',
-    'ExecutionType.CONTAINER': 'container',
-    'ExecutionType.NATIVE': 'native',
-    'container_cnt' : '#Instances'
+    "Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux": "AMD 6.6.0",
+    "Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux": "k920b 6.6.0",
+    "Linux localhost 7.1.0-rc1+  12 SMP PREEMPT_DYNAMIC Wed Apr 29 03:25:53 CST 2026 x86_64 x86_64 x86_64 GNU/Linux": "AMD 7.1.0-rc1",
+    "ExecutionType.CONTAINER": "container",
+    "ExecutionType.NATIVE": "native",
+    "container_cnt": "#Instances",
 }
 
-def to_pretty_name(ugly:str) -> str:
-    v =  COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
-    return v
-
-
-linearity = ""
-
-group_by_fields : list[str] = [BENCHMARK_FIELD, EXEC_ENV_FIELD, 'hostname', COMPARISON_FIELD, 'nb_threads']
+group_by_fields: list[str] = [
+    BENCHMARK_FIELD,
+    EXEC_ENV_FIELD,
+    "hostname",
+    COMPARISON_FIELD,
+    "nb_threads",
+]
 
 
 # this is a global variable that will be overwritten
 output_dir_name = "analysis-results"
+
+#########################################
+
+
+def to_pretty_name(ugly: str) -> str:
+    v = COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
+    return v
+
 
 def create_output_dir() -> str:
     now = datetime.now()
@@ -66,7 +72,8 @@ def create_output_dir() -> str:
     os.makedirs(dir, exist_ok=True)
     return dir
 
-def transform(file:str) -> list:
+
+def transform(file: str) -> list:
     """
     Processes a CSV file to compute per-run metrics.
 
@@ -100,32 +107,33 @@ def transform(file:str) -> list:
 
     grouped = df.groupby(group_by_fields)
     for key_group, g in grouped:
-        per_run = g.groupby(COUNT_FIELD).agg(
-            throughput_avg=(THROUGHPUT_FIELD, 'mean'),
-            success_avg=(SUCCESS_FIELD, 'mean')
-        ).reset_index()  # container_cnt becomes a column
+        per_run = (
+            g.groupby(COUNT_FIELD)
+            .agg(throughput_avg=(THROUGHPUT_FIELD, "mean"), success_avg=(SUCCESS_FIELD, "mean"))
+            .reset_index()
+        )  # container_cnt becomes a column
 
+        key_group = key_group if isinstance(key_group, tuple) else (key_group,)
         for idx, col in enumerate(group_by_fields):
             per_run[col] = key_group[idx]
 
         min_container = per_run[COUNT_FIELD].min()
-        assert 'throughput_avg' == MEASUREMENT_FIELD
+        assert "throughput_avg" == MEASUREMENT_FIELD
 
         # baseline is the throughput associated with the minimum count of containers (usually 1)
         baseline = per_run.loc[per_run[COUNT_FIELD] == min_container, MEASUREMENT_FIELD].iloc[0]
         # calc linearity
-        per_run[LINEARITY_FIELD] = per_run[MEASUREMENT_FIELD]/baseline
+        per_run[LINEARITY_FIELD] = per_run[MEASUREMENT_FIELD] / baseline
         results.append(per_run)
     return results
+
 
 def generate_patch_measurement(df, bm_name, env=""):
     subjects = df[COMPARISON_FIELD].unique()
 
     # Pivot table
     table = df.pivot_table(
-        index=COUNT_FIELD,
-        columns=COMPARISON_FIELD,
-        values=MEASUREMENT_FIELD
+        index=COUNT_FIELD, columns=COMPARISON_FIELD, values=MEASUREMENT_FIELD
     ).reset_index()
 
     # Flatten MultiIndex if it exists (common with pivot_table)
@@ -136,27 +144,27 @@ def generate_patch_measurement(df, bm_name, env=""):
     if len(subjects) >= 2:
         # First, compute improvements vs the first column (numeric!)
         first = subjects[0]
-        first_numeric  = pd.to_numeric(table[first], errors='coerce')
+        first_numeric = pd.to_numeric(table[first], errors="coerce")
         for col in subjects[1:]:
             second = col
-            second_numeric = pd.to_numeric(table[second], errors='coerce')
-            table[f'Improvement. ({second}) %'] = ((second_numeric - first_numeric) / first_numeric * 100).round(2)
-
-        # Then format all original subject columns with commas
-        for col in subjects:
-            table[col] = pd.to_numeric(table[col], errors='coerce').map(lambda x: f"{x:,.0f}" if pd.notna(x) else "")
-
+            second_numeric = pd.to_numeric(table[second], errors="coerce")
+            table[f"Improvement. ({second}) %"] = (
+                (second_numeric - first_numeric) / first_numeric * 100
+            ).round(2)
 
     table.rename(columns={COUNT_FIELD: to_pretty_name(COUNT_FIELD)}, inplace=True)
     # Convert to Markdown and write
     md_table = table.to_markdown(index=False, tablefmt="grid")
-    md_info  = f"- {bm_name}\n"
-    md_info  += f"- Execution environment: {env}\n"
+    md_info = f"- {bm_name}\n"
+    md_info += f"- Execution environment: {env}\n"
 
     write_to_file(dir=output_dir_name, fname=f"{bm_name}-{env}.txt", content=md_info + md_table)
 
-def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', plot_type=PlotType.NORMAL, env=""):
-    plot_cfg =  PlotConfig(
+
+def generate_comparison_plot(
+    df, bm_name, y="linearity", y_lbl="Linearity", plot_type=PlotType.NORMAL, env=""
+):
+    plot_cfg = PlotConfig(
         hue=COMPARISON_FIELD,
         y=y,
         y_lbl=y_lbl,
@@ -171,25 +179,24 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', plot
 def add_to_linearity_summary(df, bm, env, idx, tolerance=0.1) -> str:
     summary = f"## {idx}. {bm} ({env})\n"
     summary += f"|{COMPARISON_FIELD} | Linear | Drops at|\n"
-    summary += f"|--- |--- |---|\n"
+    summary += "|--- |--- |---|\n"
 
     for kernel, g in df.groupby(COMPARISON_FIELD):
         g_sorted = g.sort_values(COUNT_FIELD)
-        baseline = g_sorted[LINEARITY_FIELD].iloc[0]
         drops = g_sorted[g_sorted[LINEARITY_FIELD] < 1 - tolerance]
-        summary += f'|{to_pretty_name(kernel)}|'
+        summary += f"|{to_pretty_name(kernel)}|"
 
         if drops.empty:
-            summary += f'✔️|-|\n'
+            summary += "✔️|-|\n"
         else:
             first_drop_cnt = drops[COUNT_FIELD].iloc[0]
             first_drop_val = drops[LINEARITY_FIELD].iloc[0]
-            summary += f'❌|{first_drop_cnt} (linearity={first_drop_val:.2f})|\n'
+            summary += f"❌|{first_drop_cnt} (linearity={first_drop_val:.2f})|\n"
 
     return summary
 
 
-def compare(df) -> str:
+def compare(df):
     benchmarks = df[BENCHMARK_FIELD].unique()
     envs = df[EXEC_ENV_FIELD].unique()
     benchmarks.sort()
@@ -199,22 +206,33 @@ def compare(df) -> str:
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
         for env in envs:
-            bm_df = df[(df[BENCHMARK_FIELD] == bm) &
-                    (df['execution_type'] == env)]
-            if env == 'ExecutionType.CONTAINER':
+            bm_df = df[(df[BENCHMARK_FIELD] == bm) & (df["execution_type"] == env)]
+            if env == "ExecutionType.CONTAINER":
                 nice_env = "container"
             else:
                 nice_env = "native"
             generate_patch_measurement(bm_df, bm, env=nice_env)
-            generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env)
-            generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)", env=nice_env, plot_type=PlotType.SUCCESS_PERCENT)
+            generate_comparison_plot(
+                bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env
+            )
+            generate_comparison_plot(
+                bm_df,
+                bm,
+                y="success_avg",
+                y_lbl="Success Average (%)",
+                env=nice_env,
+                plot_type=PlotType.SUCCESS_PERCENT,
+            )
             generate_comparison_plot(bm_df, bm, env=nice_env)
-            Linearity_md+=add_to_linearity_summary(bm_df, bm, env=nice_env, idx=idx, tolerance=0.1)
-        idx+=1
+            Linearity_md += add_to_linearity_summary(
+                bm_df, bm, env=nice_env, idx=idx, tolerance=0.1
+            )
+        idx += 1
 
     write_to_file(Linearity_md, "linearity.md", output_dir_name)
 
-def get_all_csvs(dirs:list[str]):
+
+def get_all_csvs(dirs: list[str]):
     all_files = []
     for dir in dirs:
         if not os.path.isdir(dir):
@@ -227,16 +245,12 @@ def get_all_csvs(dirs:list[str]):
 
 
 if __name__ == "__main__":
-    """
-    """
-    parser = argparse.ArgumentParser(
-        description="Process one or more folders."
-    )
+    """ """
+    parser = argparse.ArgumentParser(description="Process one or more folders.")
     parser.add_argument(
-        "folders",
-        nargs="+",  # One or more arguments
-        help="Path(s) to folder(s) to process"
+        "folders", nargs="+", help="Path(s) to folder(s) to process"  # One or more arguments
     )
+
     args = parser.parse_args()
     output_dir_name = create_output_dir()
 
@@ -248,11 +262,11 @@ if __name__ == "__main__":
         res = transform(f)
         all.extend(res)
 
-    final_df =  pd.concat(all, ignore_index=True)
+    final_df = pd.concat(all, ignore_index=True)
     md_table = final_df.to_markdown(index=False)
 
     per_bm = compare(final_df)
-    csv  = final_df.to_csv(index=False)
+    csv = final_df.to_csv(index=False)
 
     write_to_file(dir=output_dir_name, fname="results.md", content=md_table)
     write_to_file(dir=output_dir_name, fname="results.csv", content=csv)
@@ -262,5 +276,3 @@ if __name__ == "__main__":
     dump_graphs_to_doc(output_dir_name, doc, num_plot_in_row=3)
     write_to_file(dir=output_dir_name, fname="results.html", content=doc.render())
     bm_log(f"Results written to {output_dir_name}", LogType.INFO)
-
-

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -26,6 +26,18 @@ MEASUREMENT_FIELD   = 'throughput_avg' # auto-computed
 LINEARITY_FIELD     = 'linearity' # auto-computed
 
 
+COMPARISON_FILED_PRETTY_NAME = {
+    'Linux localhost 6.6.0-138.0.0.119.oe2403sp3.x86_64  1 SMP Wed Feb  4 22:31:12 CST 2026 x86_64 x86_64 x86_64 GNU/Linux' : 'AMD 6.6.0 138',
+    'Linux k920b 6.6.0ext4noprof  9 SMP Thu Apr  9 15:34:24 CEST 2026 aarch64 aarch64 aarch64 GNU/Linux': 'k920b 6.6.0'
+}
+
+def to_pretty_name(ugly:str) -> str:
+    v =  COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
+    print(v)
+    return v
+
+
+
 linearity = ""
 
 group_by_fields : list[str] = [BENCHMARK_FIELD, EXEC_ENV_FIELD, 'hostname', COMPARISON_FIELD, 'nb_threads']
@@ -69,19 +81,39 @@ def process(file:str) -> list:
 
 def generate_patch_measurement(df, bm_name, env=""):
     subjects = df[COMPARISON_FIELD].unique()
+
+    # Map original subjects to pretty names
+    pretty_mapping = {s: to_pretty_name(s) for s in subjects}
+
+    # Pivot table
     table = df.pivot_table(
         index=COUNT_FIELD,
         columns=COMPARISON_FIELD,
         values=MEASUREMENT_FIELD
     ).reset_index()
 
-    table = table[[COUNT_FIELD] + list(subjects)]
-    md_table = table.to_markdown(index=False)
+    # Flatten MultiIndex if it exists (common with pivot_table)
+    if isinstance(table.columns, pd.MultiIndex):
+        table.columns = [col[1] if col[1] else col[0] for col in table.columns]
 
-    md_info  = f"# {bm_name}\n"
-    md_info  += f"Execution environment: {env}\n"
+    # Rename columns to pretty names immediately
+    table.rename(columns=pretty_mapping, inplace=True)
 
-    write_to_file(dir=output_dir_name, fname=f"{bm_name}-{env}.md", content=md_info + md_table)
+    # Keep COUNT_FIELD + pretty columns
+    pretty_subjects = [pretty_mapping[s] for s in subjects]
+    table = table[[COUNT_FIELD] + pretty_subjects]
+
+    # Inject improvement column between first two pretty-named columns
+    if len(pretty_subjects) >= 2:
+        first, second = pretty_subjects[:2]
+        table['diff_%'] = ((table[second] - table[first]) / table[first] * 100).round(6)
+
+    # Convert to Markdown and write
+    md_table = table.to_markdown(index=False, tablefmt="grid")
+    md_info  = f"- {bm_name}\n"
+    md_info  += f"- Execution environment: {env}\n"
+
+    write_to_file(dir=output_dir_name, fname=f"{bm_name}-{env}.txt", content=md_info + md_table)
 
 def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', env=""):
     plot_cfg =  PlotConfig(
@@ -96,7 +128,7 @@ def generate_comparison_plot(df, bm_name, y='linearity', y_lbl='Linearity', env=
     plot_chart(plot=plot_cfg, df=df, out_fig_name=f"{output_dir_name}/{bm_name}-{env}-{y_lbl}")
 
 
-def add_to_linearity_summary(df, bm, env, tolerance=0.1) -> str:
+def add_to_linearity_summary(df, bm, env, idx, tolerance=0.1) -> str:
     """
     Summarize linearity of a benchmark across kernels.
 
@@ -109,29 +141,32 @@ def add_to_linearity_summary(df, bm, env, tolerance=0.1) -> str:
     Returns:
         A one-line summary string.
     """
-    summary_parts = []
+    summary = f"## {idx}. {bm} ({env})\n"
+    summary += f"|{COMPARISON_FIELD} | Linear | Drops at|\n"
+    summary += f"|--- |--- |---|\n"
 
     for kernel, g in df.groupby(COMPARISON_FIELD):
         g_sorted = g.sort_values(COUNT_FIELD)
         baseline = g_sorted[LINEARITY_FIELD].iloc[0]
         drops = g_sorted[g_sorted[LINEARITY_FIELD] < 1 - tolerance]
+        summary += f'|{kernel}|'
 
         if drops.empty:
-            summary_parts.append(f"{kernel}: linear")
+            summary += f'✔️|-|\n'
         else:
             first_drop_cnt = drops[COUNT_FIELD].iloc[0]
             first_drop_val = drops[LINEARITY_FIELD].iloc[0]
-            summary_parts.append(
-                f"{kernel}: drops at {COUNT_FIELD}={first_drop_cnt} (linearity={first_drop_val:.2f})"
-            )
+            summary += f'❌|{first_drop_cnt} (linearity={first_drop_val:.2f})|\n'
 
-    print(f"{bm} ({env}) -> " + "\n ".join(summary_parts))
+    return summary
 
 
 def compare(df) -> str:
     benchmarks = df[BENCHMARK_FIELD].unique()
     envs = df[EXEC_ENV_FIELD].unique()
     benchmarks.sort()
+    Linearity_md = "# Linearity Summary\n"
+    idx = 1
     # get all results mapped to a certain benchmark
     for bm in benchmarks:
         for env in envs:
@@ -145,7 +180,10 @@ def compare(df) -> str:
             generate_comparison_plot(bm_df, bm, y=MEASUREMENT_FIELD, y_lbl="Throughput Average", env=nice_env)
             generate_comparison_plot(bm_df, bm, y="success_avg", y_lbl="Success Average (%)", env=nice_env)
             generate_comparison_plot(bm_df, bm, env=nice_env)
-            add_to_linearity_summary(bm_df, bm, env=nice_env, tolerance=0.1)
+            Linearity_md+=add_to_linearity_summary(bm_df, bm, env=nice_env, idx=idx, tolerance=0.1)
+        idx+=1
+
+    write_to_file(Linearity_md, "linearity.md", output_dir_name)
 
 def get_files(folders):
     all_files = []

--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -33,7 +33,6 @@ COMPARISON_FILED_PRETTY_NAME = {
 
 def to_pretty_name(ugly:str) -> str:
     v =  COMPARISON_FILED_PRETTY_NAME.get(ugly, ugly)
-    print(v)
     return v
 
 
@@ -106,7 +105,9 @@ def generate_patch_measurement(df, bm_name, env=""):
     # Inject improvement column between first two pretty-named columns
     if len(pretty_subjects) >= 2:
         first, second = pretty_subjects[:2]
-        table['diff_%'] = ((table[second] - table[first]) / table[first] * 100).round(6)
+        table['diff_%'] = ((table[second] - table[first]) / table[first] * 100)
+        table[second] = table[second].map(lambda x: f"{x:,.0f}")
+        table[first]  = table[first].map(lambda x: f"{x:,.0f}")
 
     # Convert to Markdown and write
     md_table = table.to_markdown(index=False, tablefmt="grid")

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -14,7 +14,7 @@ import json
 from utils.logger import bm_log, LogType
 from benchkit.utils.types import PathType
 from utils.bm_builder import Builder
-
+import pandas as pd
 
 def resolve_path(path: PathType, use_in_container: bool = False) -> PathType:
     """
@@ -285,3 +285,32 @@ def get_host_ip() -> str:
     finally:
         s.close()
     return ip
+
+def write_to_file(content : str, fname :str, dir : str):
+    os.makedirs(dir, exist_ok=True)
+    file_path = os.path.join(dir, fname)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def get_all_files_by_ext(dir:str, extension:str = ".csv"):
+    """
+    Returns all files under the given dir and subdirs, which have the given file extension.
+    """
+    filtered_files = []
+    for root, _, files  in os.walk(dir):
+        for file in files:
+            if file.endswith(extension):
+                abs_path = os.path.join(root, file)
+                filtered_files.append(abs_path)
+    return filtered_files
+
+def read_data_frame_from_csv(file:str) -> Optional[pd.DataFrame]:
+    try:
+        df = pd.read_csv(
+            file, sep=";", comment="#", engine="python", on_bad_lines="error"
+        )
+        return df
+    except Exception as e:
+        bm_log(f"{e} on {file}", LogType.ERROR)
+        return None

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -16,6 +16,7 @@ from benchkit.utils.types import PathType
 from utils.bm_builder import Builder
 import pandas as pd
 
+
 def resolve_path(path: PathType, use_in_container: bool = False) -> PathType:
     """
     Returns the absolute path of the given path with respect to
@@ -286,30 +287,30 @@ def get_host_ip() -> str:
         s.close()
     return ip
 
-def write_to_file(content : str, fname :str, dir : str):
+
+def write_to_file(content: str, fname: str, dir: str):
     os.makedirs(dir, exist_ok=True)
     file_path = os.path.join(dir, fname)
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
-def get_all_files_by_ext(dir:str, extension:str = ".csv"):
+def get_all_files_by_ext(dir: str, extension: str = ".csv"):
     """
     Returns all files under the given dir and subdirs, which have the given file extension.
     """
     filtered_files = []
-    for root, _, files  in os.walk(dir):
+    for root, _, files in os.walk(dir):
         for file in files:
             if file.endswith(extension):
                 abs_path = os.path.join(root, file)
                 filtered_files.append(abs_path)
     return filtered_files
 
-def read_data_frame_from_csv(file:str) -> Optional[pd.DataFrame]:
+
+def read_data_frame_from_csv(file: str) -> Optional[pd.DataFrame]:
     try:
-        df = pd.read_csv(
-            file, sep=";", comment="#", engine="python", on_bad_lines="error"
-        )
+        df = pd.read_csv(file, sep=";", comment="#", engine="python", on_bad_lines="error")
         return df
     except Exception as e:
         bm_log(f"{e} on {file}", LogType.ERROR)

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -41,6 +41,7 @@ def plot_chart(
     df: DataFrame,
     out_fig_name,
     add_points=False,
+    gen_pdf=False,
     **kwargs,
 ):
     args = dict(kwargs)
@@ -100,7 +101,8 @@ def plot_chart(
     fig.tight_layout()
     figure_name = f"{out_fig_name}_{time.perf_counter()}"
     fig.savefig(f"{figure_name}.png", transparent=False)
-    fig.savefig(f"{figure_name}.pdf", transparent=False)
+    if gen_pdf:
+        fig.savefig(f"{figure_name}.pdf", transparent=False)
     plt.close()
 
 

--- a/helpers/analyze.py
+++ b/helpers/analyze.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import pandas as pd
 
@@ -57,7 +58,7 @@ def process(file:str) -> list:
         return results
 
 if __name__ == "__main__":
-    folder = "/home/lilith/workspace/csb/results-csv"
+    folder = "/home/lilith/workspace/csb-analyze/results"
     files = find_csvs(folder)
     all = []
     for f in files:

--- a/helpers/analyze.py
+++ b/helpers/analyze.py
@@ -3,12 +3,13 @@ import pandas as pd
 
 # collect all csvs in the given folder
 def find_csvs(folder_path:str):
-    files = []
-    for file_name in os.listdir(folder_path):
-        if file_name.endswith(".csv"):
-            file_path = os.path.join(folder_path, file_name)
-            files.append(file_path)
-    return files
+    csvs = []
+    for root, dirs, files  in os.walk(folder_path):
+        for file in files:
+            if file.endswith(".csv"):
+                file_path = os.path.join(root, file)
+                csvs.append(file_path)
+    return csvs
 
 # Allowed CPUs
 # kernel
@@ -24,7 +25,7 @@ def process(file:str) -> list:
         df = pd.read_csv(
             file, sep=";", comment="#", engine="python", on_bad_lines="error"
         )
-        grouped = df.groupby(['algo_name', 'execution_type', 'kernel', 'num_threads'])
+        grouped = df.groupby(['algo_name', 'execution_type', 'kernel', 'nb_threads'])
         for key, g in grouped:
             algo_name, execution_type, kernel, num_threads = key
 
@@ -56,7 +57,7 @@ def process(file:str) -> list:
         return results
 
 if __name__ == "__main__":
-    folder = "/home/lilith/workspace/csb/amd-results"
+    folder = "/home/lilith/workspace/csb/results-csv"
     files = find_csvs(folder)
     all = []
     for f in files:
@@ -65,5 +66,8 @@ if __name__ == "__main__":
 
     final_df = pd.DataFrame(all)
     md_table = final_df.to_markdown(index=False)
+    csv  = final_df.to_csv(index=False)
     with open("results.md", "w") as f:
          f.write(md_table)
+    with open("results.csv", "w") as f:
+         f.write(csv)

--- a/helpers/analyze.py
+++ b/helpers/analyze.py
@@ -17,7 +17,7 @@ def find_csvs(folder_path:str):
 # algo_name
 # execution_type // group by
 
-def process(file:str):
+def process(file:str) -> list:
     tolerance = 0.1  # 10% tolerance
     results = []
     try:
@@ -50,16 +50,20 @@ def process(file:str):
                 'Drops at': drop_note
             })
 
-        final_df = pd.DataFrame(results)
-        md_table = final_df.to_markdown(index=False)
-        with open("results.md", "w") as f:
-            f.write(md_table)
+        return results
     except Exception as e:
         print(f"{e} on {file}")
+        return results
 
 if __name__ == "__main__":
     folder = "/home/lilith/workspace/csb/amd-results"
     files = find_csvs(folder)
+    all = []
     for f in files:
-        process(f)
-        break
+        res = process(f)
+        all.extend(res)
+
+    final_df = pd.DataFrame(all)
+    md_table = final_df.to_markdown(index=False)
+    with open("results.md", "w") as f:
+         f.write(md_table)

--- a/helpers/analyze.py
+++ b/helpers/analyze.py
@@ -1,0 +1,65 @@
+import os
+import pandas as pd
+
+# collect all csvs in the given folder
+def find_csvs(folder_path:str):
+    files = []
+    for file_name in os.listdir(folder_path):
+        if file_name.endswith(".csv"):
+            file_path = os.path.join(folder_path, file_name)
+            files.append(file_path)
+    return files
+
+# Allowed CPUs
+# kernel
+# throughput_min  // avg
+# univ_succ_percent
+# algo_name
+# execution_type // group by
+
+def process(file:str):
+    tolerance = 0.1  # 10% tolerance
+    results = []
+    try:
+        df = pd.read_csv(
+            file, sep=";", comment="#", engine="python", on_bad_lines="error"
+        )
+        grouped = df.groupby(['algo_name', 'execution_type', 'kernel', 'num_threads'])
+        for key, g in grouped:
+            algo_name, execution_type, kernel, num_threads = key
+
+            avg_per_container = g.groupby('container_cnt')['throughput_min'].mean()
+            min_container     = avg_per_container.index.min()
+            avg_min_throughput = avg_per_container[min_container]
+            linearity_per_count = avg_per_container / avg_min_throughput
+
+            dropped = linearity_per_count[(linearity_per_count < (1 - tolerance))]
+            if dropped.empty:
+                checkmark = "✔"
+                drop_note = ""
+            else:
+                checkmark = "✘"
+                drop_note = str(dropped.index.min())
+
+            results.append({
+                'Benchmark': algo_name,
+                'Execution Unit': execution_type,
+                'Kernel': kernel,
+                'Number of Threads': num_threads,
+                'linear': checkmark,
+                'Drops at': drop_note
+            })
+
+        final_df = pd.DataFrame(results)
+        md_table = final_df.to_markdown(index=False)
+        with open("results.md", "w") as f:
+            f.write(md_table)
+    except Exception as e:
+        print(f"{e} on {file}")
+
+if __name__ == "__main__":
+    folder = "/home/lilith/workspace/csb/amd-results"
+    files = find_csvs(folder)
+    for f in files:
+        process(f)
+        break


### PR DESCRIPTION
Add

- `analyze.py‎` script. The script compares the benchmarks
   behavior across kernels, and generates different types of
   reports and graphs. Among those is a linearity report,
  and a plain text throughput comparison table. 
 
Change

- add more functions to `bm_utils`