### PR TITLE
[bm-runner] Redirect container and native errors to err file.

### DIFF
--- a/bm-runner/bm_container.py
+++ b/bm-runner/bm_container.py
@@ -164,7 +164,7 @@ class Container(ExecutionUnit):
                 return source
 
         bm_log(
-            f"CSB container doesn't map '{home_dir}'. Can't create subcontainers",
+            f"CSB container doesn't map '{home_dir}'. Can't create sub-containers",
             LogType.ERROR,
         )
         return None
@@ -192,7 +192,7 @@ class Container(ExecutionUnit):
                 cpuset_cpus=self.core_set,
                 volumes=volumes,
                 privileged=True,  # privileged mode
-                detach=True,  # detach mode
+                detach=True,  # detached mode
                 working_dir="/home",
                 ports=ports,
             )
@@ -225,7 +225,7 @@ class Container(ExecutionUnit):
         if self.app.cd:
             assert self.app.path is not None, "path is not set while change directory is requested!"
             command = f"cd {self.app.path} && {command}"
-        commands = f"{self.CMD_WHILE_NOT_START} {command} > {resolve_path(self.output_file, use_in_container=True)}"  # same as self.output_file outside container.
+        commands = f"{self.CMD_WHILE_NOT_START} {command} > {resolve_path(self.output_file, use_in_container=True)} 2> {resolve_path(self.err_file, use_in_container=True)}"  # same as self.output_file outside container.
         return self.__start(commands)
 
 

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -30,7 +30,8 @@ class ExecutionUnit:
         self.home_dir = home_dir
         self.name = "C" if type == ExecutionType.CONTAINER else "N"
         self.name += f"{idx:03d}_{app.name}"
-        self.output_file = os.path.join(Application.BUILTIN_APP_DIR, self.name)
+        self.output_file    = os.path.join(Application.BUILTIN_APP_DIR, self.name)
+        self.err_file       = os.path.join(Application.BUILTIN_APP_DIR, f"{self.name}_err")
 
     @abstractmethod
     def get_results_dir(self) -> str:

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -30,8 +30,8 @@ class ExecutionUnit:
         self.home_dir = home_dir
         self.name = "C" if type == ExecutionType.CONTAINER else "N"
         self.name += f"{idx:03d}_{app.name}"
-        self.output_file    = os.path.join(Application.BUILTIN_APP_DIR, self.name)
-        self.err_file       = os.path.join(Application.BUILTIN_APP_DIR, f"{self.name}_err")
+        self.output_file = os.path.join(Application.BUILTIN_APP_DIR, self.name)
+        self.err_file = os.path.join(Application.BUILTIN_APP_DIR, f"{self.name}_err")
 
     @abstractmethod
     def get_results_dir(self) -> str:

--- a/bm-runner/bm_process.py
+++ b/bm-runner/bm_process.py
@@ -40,15 +40,16 @@ class Process(ExecutionUnit):
         commands = (
             f"{self.CMD_WHILE_NOT_START}{change_dir}taskset --cpu-list {self.core_set} {command}"
         )
-        with open(resolve_path(self.output_file), "w") as outfile:
-            self.process = subprocess.Popen(
-                commands,
-                shell=True,
-                stdout=outfile,
-                stderr=subprocess.DEVNULL,
-                preexec_fn=preexec_process,
-                cwd=self.home_dir,
-            )
+        with open(resolve_path(self.err_file), "w") as err_file:
+            with open(resolve_path(self.output_file), "w") as outfile:
+                self.process = subprocess.Popen(
+                    commands,
+                    shell=True,
+                    stdout=outfile,
+                    stderr=err_file,
+                    preexec_fn=preexec_process,
+                    cwd=self.home_dir,
+                )
         bm_log(f"launched process {self.name} with {commands}")
         return True
 


### PR DESCRIPTION
Change

- add error file for containers, and native processes
   redirect `stderr` to it.