### PR TITLE
[bm-runner] Log errors to `stderr`.

### DIFF
--- a/bm-runner/utils/logger.py
+++ b/bm-runner/utils/logger.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime
 from enum import Enum
+import sys
 
 
 class LogType(str, Enum):
@@ -15,5 +16,10 @@ class LogType(str, Enum):
 
 def bm_log(msg: str, t: LogType = LogType.DEBUG):
     RESET: str = "\033[0m"
-    time = datetime.now().strftime("%H:%M:%S.%f")
-    print(f"{t.value}{time} [{t.name}] {msg}{RESET}")
+    current_time = datetime.now().strftime("%H:%M:%S.%f")
+    match t:
+        case LogType.ERROR | LogType.FATAL:
+            file=sys.stderr
+        case _:
+            file=sys.stdout
+    print(f"{t.value}{current_time} [{t.name}] {msg}{RESET}", file=file)

--- a/bm-runner/utils/logger.py
+++ b/bm-runner/utils/logger.py
@@ -19,7 +19,7 @@ def bm_log(msg: str, t: LogType = LogType.DEBUG):
     current_time = datetime.now().strftime("%H:%M:%S.%f")
     match t:
         case LogType.ERROR | LogType.FATAL:
-            file=sys.stderr
+            file = sys.stderr
         case _:
-            file=sys.stdout
+            file = sys.stdout
     print(f"{t.value}{current_time} [{t.name}] {msg}{RESET}", file=file)


### PR DESCRIPTION
Change

- `bm_log` writes error and fatal logs to `stderr`.