### PR TITLE
[bm-runner] Detect cgroups version and add it to the csv output.

### DIFF
--- a/bm-runner/benchmark.py
+++ b/bm-runner/benchmark.py
@@ -9,6 +9,7 @@ from benchkit.benchmark import (
 import sys
 from typing import Optional, Dict, Any, List
 import bm_utils
+from bm_utils import get_cgroups_version
 from bm_container import Containers
 from bm_process import Processes
 from config.benchmark import ExecutionType
@@ -48,6 +49,7 @@ class ScalabilityBenchmark(Benchmark):
         kernel_info = kernel_info.strip()
         self.common_info["kernel"] = kernel_info.replace("#", " ")
         self.common_info["Allowed CPUs"] = self.container_cfg.get_cpu_pool()
+        self.common_info["cgroup"] = get_cgroups_version()
 
     def prebuild_bench(self, **_kwargs):
         b = Builder()

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -325,9 +325,9 @@ def get_cgroups_version() -> str:
     # then cgroup v2 is in use. If it returns
     # `tmpfs` then most likely v1 is in use.
     cgroup = shell_out(
-        command="stat -f -c %T /sys/fs/cgroup",
+        command="cat /proc/mounts",
         output_is_log=False,
         print_file_shell_cmd=False,
     ).strip()
-    version = "v2" if cgroup == "cgroup2fs" else "v1"
-    return f"{cgroup}({version})"
+    version = "v2" if "cgroup2".lower() in cgroup.lower() else "v1"
+    return f"{version}"

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -315,3 +315,18 @@ def read_data_frame_from_csv(file: str) -> Optional[pd.DataFrame]:
     except Exception as e:
         bm_log(f"{e} on {file}", LogType.ERROR)
         return None
+
+def get_cgroups_version() -> str:
+    """
+    Returns the used version of cgroups.
+    """
+    # if the following command returns `cgroup2fs`,
+    # then cgroup v2 is in use. If it returns
+    # `tmpfs` then most likely v1 is in use.
+    cgroup = shell_out(
+        command=f"stat -f -c %T /sys/fs/cgroup",
+        output_is_log=False,
+        print_file_shell_cmd=False,
+    )
+    version = "v2" if cgroup == "cgroup2fs" else "v1"
+    return f"{cgroup} -> {version}"

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -316,6 +316,7 @@ def read_data_frame_from_csv(file: str) -> Optional[pd.DataFrame]:
         bm_log(f"{e} on {file}", LogType.ERROR)
         return None
 
+
 def get_cgroups_version() -> str:
     """
     Returns the used version of cgroups.
@@ -324,9 +325,9 @@ def get_cgroups_version() -> str:
     # then cgroup v2 is in use. If it returns
     # `tmpfs` then most likely v1 is in use.
     cgroup = shell_out(
-        command=f"stat -f -c %T /sys/fs/cgroup",
+        command="stat -f -c %T /sys/fs/cgroup",
         output_is_log=False,
         print_file_shell_cmd=False,
-    )
+    ).strip()
     version = "v2" if cgroup == "cgroup2fs" else "v1"
-    return f"{cgroup} -> {version}"
+    return f"{cgroup}({version})"


### PR DESCRIPTION
Change

- add `get_cgroups_version` function
- append the output to the generated csv