### PR TITLE
Check errors

### DIFF
--- a/bm-runner/bm_container.py
+++ b/bm-runner/bm_container.py
@@ -225,7 +225,16 @@ class Container(ExecutionUnit):
         if self.app.cd:
             assert self.app.path is not None, "path is not set while change directory is requested!"
             command = f"cd {self.app.path} && {command}"
-        commands = f"{self.CMD_WHILE_NOT_START} {command} > {resolve_path(self.output_file, use_in_container=True)} 2> {resolve_path(self.err_file, use_in_container=True)}"  # same as self.output_file outside container.
+
+        output_file = resolve_path(self.output_file, use_in_container=True)
+        err_file = resolve_path(self.err_file, use_in_container=True)
+
+        assert os.path.isdir(
+            os.path.dirname(output_file)
+        ), f"dir to store {output_file} doesn't exist!"
+        assert os.path.isdir(os.path.dirname(err_file)), f"dir to store {err_file} doesn't exist!"
+
+        commands = f"{self.CMD_WHILE_NOT_START} {command} > {output_file} 2> {err_file}"  # same as self.output_file outside container.
         return self.__start(commands)
 
 

--- a/bm-runner/bm_process.py
+++ b/bm-runner/bm_process.py
@@ -40,18 +40,25 @@ class Process(ExecutionUnit):
         commands = (
             f"{self.CMD_WHILE_NOT_START}{change_dir}taskset --cpu-list {self.core_set} {command}"
         )
-        with open(resolve_path(self.err_file), "w") as err_file:
-            with open(resolve_path(self.output_file), "w") as outfile:
-                self.process = subprocess.Popen(
-                    commands,
-                    shell=True,
-                    stdout=outfile,
-                    stderr=err_file,
-                    preexec_fn=preexec_process,
-                    cwd=self.home_dir,
-                )
-        bm_log(f"launched process {self.name} with {commands}")
-        return True
+        try:
+            with open(resolve_path(self.err_file), "w") as err_file:
+                with open(resolve_path(self.output_file), "w") as outfile:
+                    self.process = subprocess.Popen(
+                        commands,
+                        shell=True,
+                        stdout=outfile,
+                        stderr=err_file,
+                        preexec_fn=preexec_process,
+                        cwd=self.home_dir,
+                    )
+            bm_log(f"launched process {self.name} with {commands}")
+            return True
+        except OSError as e:
+            bm_log(
+                f"process {self.name} got an OSError: {repr(e)}",
+                LogType.FATAL,
+            )
+            sys.exit(1)
 
     def wait(self):
         if self.process is None:


### PR DESCRIPTION
bm_container: check if directory exists before starting a container
    
    If CSB does some wrong mapping while starting a container, no
    output message will be displayed. That makes developers spend
    a lot of time trying to debug problems at config files that are
    actually due to CSB internal issues.
    
    Change the logic to assert that the mapping was properly handled
    inside the container and the output dir exists before actually
    start executing a container job.
    
bm_process: check open errors while running process
    
    Catch if an OSError happens when trying to execute a process,
    as some problem may happen in CSB when trying to open output
    and/or error files.
 