### PR TITLE
[bm-runner] Fix `min_max_avg` plot and add it to sysbench config.

### DIFF
--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -116,14 +116,13 @@ def plot_chart(
     plot: PlotConfig,
     df: DataFrame,
     out_fig_name,
-    add_points:bool = False,
-    gen_pdf:bool = False,
+    add_points: bool = False,
+    gen_pdf: bool = False,
     **kwargs,
 ):
     pc = PlotChart(plot)
     pc.add(plot, df, add_points=add_points, **kwargs)
     pc.save(out_fig_name, gen_pdf)
-
 
 
 ###########################################################################
@@ -237,36 +236,82 @@ def create_min_max_avg_plot(org_df, config: PlotConfig, dir: str):
         dir (str): where to store the plot.
     """
     prefix = config.y
-    min_col = f"{prefix}_min"
-    max_col = f"{prefix}_max"
-    avg_col = f"{prefix}_avg"
     df = org_df.copy()
-    if avg_col not in df.columns:
-        df[avg_col] = (df[min_col] + df[max_col]) / 2
-    else:
-        # maximum avg value
-        # max_avg = max(df[avg_col])
-        # minimum a max value
-        min_max = min(df[max_col])
-        if min_max != 0:
-            # transformation factor
-            # alpha = max_avg / min_max
-            # transform max to max*alpha
-            df[max_col] = list(map(lambda avg, max: avg + (avg // max), df[avg_col], df[max_col]))
+    pc = PlotChart(config)
+    min_col = None
+    avg_col = None
+    max_col = None
+    percentile = None
+    metric = None
 
-    sdf = df[[config.x, config.hue, min_col, avg_col, max_col]]
+    for c in df.columns:
+        if c.startswith(prefix):
+            if c.endswith("avg_col"):
+                avg_col = c
+            if c.endswith("percentile"):
+                percentile = c
+
+            if c.endswith("min"):
+                min_col = c
+
+            if c.endswith("max"):
+                max_col = c
+
+    if not min_col or not max_col:
+        return
+
+    # If both percentile and average are present, use percentile, as it
+    # provides an expected value for the metric on most cases.
+
+    if percentile:
+        metric = percentile
+    elif avg_col:
+        metric = avg_col
+
+    if metric:
+        tmp_config = PlotConfig(**config)
+        tmp_config.y = metric
+
+        pc.add(
+            tmp_config,
+            df[[config.x, config.hue, metric]],
+            estimator="mean",
+        )
+
+        # Mathplotlib will always calculate its own average line, calculated
+        # using multiple Y samples for each X value. When the average metric
+        # is calculated by the benchmark, we need to replace it by the data
+        # calculated at by the tool, as otherwise the calculus will be wrong.
+        # So, make the melt data average line invisible.
+        linewidth = 0
+        legend = False
+    else:
+        # Plot estimated average
+        linewidth = 1
+        legend = True
+
     transformed_data = pd.melt(
-        sdf,
+        df[[config.x, config.hue, min_col, max_col]],
         id_vars=[config.hue, config.x],
-        value_vars=[min_col, avg_col, max_col],
+        value_vars=[min_col, max_col],
         value_name=config.y,
+        var_name="metric",
     )
-    plot_chart(
-        plot=config,
-        df=transformed_data,
-        out_fig_name=f"{dir}/{config.y}_min_avg_max",
-        estimator="median",
+
+    pc.add(
+        config,
+        transformed_data,
+        linewidth=linewidth,
+        legend=legend,
+        estimator="mean",
+        # Mathplotlib doesn't really show max/min. Instead, it tries to
+        # filter out values too high/too or low. Its default is to use a
+        # standard distribution. Instead, use a more realistic error bar
+        # using percentile.
+        errorbar="pi",
     )
+
+    pc.save(out_fig_name=f"{dir}/{config.y}_min_avg_max")
 
 
 ###########################################################

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -36,74 +36,94 @@ def col_exists(df: DataFrame, col: str, title: str) -> bool:
     return True
 
 
+class PlotChart:
+    def __init__(self, plot: "PlotConfig"):
+        self.fig = plt.figure(dpi=150)
+
+        self.chart = self.fig.add_subplot()
+        self.chart.set_title(plot.title)
+
+    def add(
+        self,
+        plot: "PlotConfig",
+        df: DataFrame,
+        add_points: bool = False,
+        **kwargs,
+    ):
+        args = dict(kwargs)
+        # prep hue, we want to generate enough colors
+        cnt = df[plot.hue].nunique()
+        sorted_gp = sorted(df[plot.hue].unique())
+        palette = sns.color_palette(palette="hls", n_colors=cnt)
+        sns_plot_fun = getattr(sns, plot.shape)
+
+        if (
+            not col_exists(df, plot.y, plot.title)
+            or not col_exists(df, plot.x, plot.title)
+            or not col_exists(df, plot.hue, plot.title)
+        ):
+            return
+
+        chart = sns_plot_fun(
+            ax=self.chart,
+            data=df,
+            palette=palette,
+            x=plot.x,
+            hue=plot.hue,
+            hue_order=sorted_gp,
+            y=plot.y,
+            **args,
+        )
+        if add_points:
+            sns.scatterplot(
+                x=plot.x,
+                y=plot.y,
+                hue=plot.hue,
+                markers=plot.hue,
+                data=df,
+                hue_order=sorted_gp,
+                palette=palette,
+                ax=chart,
+                legend=False,
+            )
+
+        chart.set(xlabel=plot.x_lbl, ylabel=plot.y_lbl)
+        chart.grid(True)
+        new_ylim = 1.2 * max(df[plot.y])
+        chart.set_ylim(0, 1 if new_ylim == 0 else new_ylim)
+
+        plt.legend(
+            loc="upper left",
+            title=f"{plot.hue_lbl}",
+            bbox_to_anchor=(1, 1),
+            borderaxespad=0.3,
+            fontsize=4.5,
+        )
+
+    def save(self, out_fig_name, gen_pdf: bool = False):
+
+        self.fig.set_size_inches(w=10, h=8)
+        self.fig.tight_layout()
+
+        figure_name = f"{out_fig_name}_{time.perf_counter()}"
+        self.fig.savefig(f"{figure_name}.png", transparent=False)
+        if gen_pdf:
+            self.fig.savefig(f"{figure_name}.pdf", transparent=False)
+        plt.close()
+
+
 def plot_chart(
     plot: PlotConfig,
     df: DataFrame,
     out_fig_name,
-    add_points=False,
-    gen_pdf=False,
+    add_points:bool = False,
+    gen_pdf:bool = False,
     **kwargs,
 ):
-    args = dict(kwargs)
-    fig = plt.figure(dpi=150)
-    chart = fig.add_subplot()
-    chart.set_title(plot.title)
-    # prep hue, we want to generate enough colors
-    cnt = df[plot.hue].nunique()
-    sorted_gp = sorted(df[plot.hue].unique())
-    palette = sns.color_palette(palette="hls", n_colors=cnt)
-    sns_plot_fun = getattr(sns, plot.shape)
+    pc = PlotChart(plot)
+    pc.add(plot, df, add_points=add_points, **kwargs)
+    pc.save(out_fig_name, gen_pdf)
 
-    if (
-        not col_exists(df, plot.y, plot.title)
-        or not col_exists(df, plot.x, plot.title)
-        or not col_exists(df, plot.hue, plot.title)
-    ):
-        return
-
-    chart = sns_plot_fun(
-        ax=chart,
-        data=df,
-        palette=palette,
-        x=plot.x,
-        hue=plot.hue,
-        hue_order=sorted_gp,
-        y=plot.y,
-        **args,
-    )
-    if add_points:
-        sns.scatterplot(
-            x=plot.x,
-            y=plot.y,
-            hue=plot.hue,
-            markers=plot.hue,
-            data=df,
-            hue_order=sorted_gp,
-            palette=palette,
-            ax=chart,
-            legend=False,
-        )
-
-    chart.set(xlabel=plot.x_lbl, ylabel=plot.y_lbl)
-    chart.grid(True)
-    new_ylim = 1.2 * max(df[plot.y])
-    chart.set_ylim(0, 1 if new_ylim == 0 else new_ylim)
-
-    plt.legend(
-        loc="upper left",
-        title=f"{plot.hue_lbl}",
-        bbox_to_anchor=(1, 1),
-        borderaxespad=0.3,
-        fontsize=4.5,
-    )
-
-    fig.set_size_inches(w=10, h=8)
-    fig.tight_layout()
-    figure_name = f"{out_fig_name}_{time.perf_counter()}"
-    fig.savefig(f"{figure_name}.png", transparent=False)
-    if gen_pdf:
-        fig.savefig(f"{figure_name}.pdf", transparent=False)
-    plt.close()
 
 
 ###########################################################################

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -37,7 +37,7 @@ def col_exists(df: DataFrame, col: str, title: str) -> bool:
 
 
 class PlotChart:
-    def __init__(self, plot: "PlotConfig"):
+    def __init__(self, plot: PlotConfig):
         self.fig = plt.figure(dpi=150)
 
         self.chart = self.fig.add_subplot()
@@ -45,7 +45,7 @@ class PlotChart:
 
     def add(
         self,
-        plot: "PlotConfig",
+        plot: PlotConfig,
         df: DataFrame,
         add_points: bool = False,
         **kwargs,
@@ -227,8 +227,8 @@ def create_success_rate_plot(org_df, config: PlotConfig, dir):
 def create_min_max_avg_plot(org_df, config: PlotConfig, dir: str):
     """
     Treats `config.y` as a prefix and look for min, max, and avg values
-    It assumes such columns exist in the dataframe <config.y>_min,
-    <config.y>_max & <config.y>_avg
+    It assumes such columns exist in the dataframe <config.y>min,
+    <config.y>max and, optionally, <config.y>percentile or <config.y>avg
 
     Args:
         org_df: dataframe
@@ -246,7 +246,7 @@ def create_min_max_avg_plot(org_df, config: PlotConfig, dir: str):
 
     for c in df.columns:
         if c.startswith(prefix):
-            if c.endswith("avg_col"):
+            if c.endswith("avg"):
                 avg_col = c
             if c.endswith("percentile"):
                 percentile = c

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -13,7 +13,7 @@ class PlotType(str, Enum):
     ----------
     NORMAL: Plots according to the config no post processing of data.
     MEAN: Plots the mean value of execution units' throughput (`y` value specified in plot config) per run.
-    MIN_MAX_AVG: Experimental, Plots min, max and average time of operations.
+    MIN_MAX_AVG: Plots min, max optionally with percentile or average time of operations.
     HISTOGRAM: Experimental, Plots the distribution of operations.
     SUCCESS_PERCENT: Experimental, Plots the percentage of successful operations.
     LINEARITY: Calculates and plots the linearity of the benchmark results.

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_delete.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_delete.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_delete latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_insert.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_insert.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_insert latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_point_select.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_point_select.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_point_select latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_read_only.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_read_only.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_read_only latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_read_write.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_read_write.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_read_write latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_update_index.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_update_index.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_update_index latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_update_non_index.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_update_non_index.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_update_non_index latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-oltp_write_only.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-oltp_write_only.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB oltp_write_only latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-select_random_points.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-select_random_points.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB select_random_points latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/config/bm-external/sysbench/sysbench-mariadb-select_random_ranges.json
+++ b/config/bm-external/sysbench/sysbench-mariadb-select_random_ranges.json
@@ -3,6 +3,17 @@
     {
       "x": "container_cnt",
       "x_lbl": "#Containers",
+      "y": "latency",
+      "y_lbl": "Latency (min/max/95% percentile)",
+      "hue_lbl": "Executer",
+      "hue": "execution_type",
+      "shape": "lineplot",
+      "type": "min_max_avg",
+      "title": "Sysbench MariaDB select_random_ranges latency vs. #container"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Containers",
       "y": "sql_statistics.queries_performed.read",
       "y_lbl": "Read Throughput",
       "hue_lbl": "Executer",

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -123,7 +123,7 @@ Monitors are used to monitor performance. They can be used to analyze the behavi
 Supported types of plots.  <br/>Supported values:
 - `"normal"`:  Plots according to the config no post processing of data.
 - `"mean"`:  Plots the mean value of execution units' throughput (`y` value specified in plot config) per run.
-- `"min_max_avg"`:  Experimental, Plots min, max and average time of operations.
+- `"min_max_avg"`:  Plots min, max optionally with percentile or average time of operations.
 - `"histogram"`:  Experimental, Plots the distribution of operations.
 - `"success_percent"`:  Experimental, Plots the percentage of successful operations.
 - `"linearity"`:  Calculates and plots the linearity of the benchmark results.

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -71,7 +71,7 @@ Plot configuration for benchmark results. Represented as a JSON array of objects
 |hue_lbl|str|:white_check_mark:|`{hue}`|    The label for the hue/groupby. If None, defaults to `{hue}`. |
 |title|str|:white_check_mark:|`{x_lbl} vs. {y_lbl}`|    The title of the plot. If None, defaults to `{x_lbl} vs. {y_lbl}`. |
 |shape|str|:white_check_mark:||    The shape/type of the plot (e.g., 'lineplot', 'barplot'). If None, defaults based on `type`. |
-|type|[PlotType](#plottype)|:white_check_mark:|`PlotType.NORMAL`|    The type of plot to be created, which determines default shape and other behaviors. |
+|type|[PlotType](#plottype)|:white_check_mark:|`normal`|    The type of plot to be created, which determines default shape and other behaviors. |
 
 ## NicsConfig
 NicsConfig configures the assignment of Network Interface Cards (NICs) or their Virtual Functions (VFs) to containers. Represented as a JSON object. 
@@ -110,8 +110,8 @@ Adapters used to transform the output of an external benchmark into the format u
 CPU/Core assignment policy for execution units, i.e. containers and native processes.  
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`PackGroup.NO_PACK`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
-|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`CpuOrder.ASC`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
+|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`none`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
+|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`asc`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
 |one_cpu_per_core|bool|:white_check_mark:|`False`|    Whether to use only one CPU from each Core. This is relevant to hyper-threading     when multiple CPUs share the same core. When set to true, from each core only     the first CPU is considered. |
 ## MonitorType
 Monitors are used to monitor performance. They can be used to analyze the behavior of the benchmarks.  <br/>Supported values:

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -71,7 +71,7 @@ Plot configuration for benchmark results. Represented as a JSON array of objects
 |hue_lbl|str|:white_check_mark:|`{hue}`|    The label for the hue/groupby. If None, defaults to `{hue}`. |
 |title|str|:white_check_mark:|`{x_lbl} vs. {y_lbl}`|    The title of the plot. If None, defaults to `{x_lbl} vs. {y_lbl}`. |
 |shape|str|:white_check_mark:||    The shape/type of the plot (e.g., 'lineplot', 'barplot'). If None, defaults based on `type`. |
-|type|[PlotType](#plottype)|:white_check_mark:|`normal`|    The type of plot to be created, which determines default shape and other behaviors. |
+|type|[PlotType](#plottype)|:white_check_mark:|`PlotType.NORMAL`|    The type of plot to be created, which determines default shape and other behaviors. |
 
 ## NicsConfig
 NicsConfig configures the assignment of Network Interface Cards (NICs) or their Virtual Functions (VFs) to containers. Represented as a JSON object. 
@@ -110,8 +110,8 @@ Adapters used to transform the output of an external benchmark into the format u
 CPU/Core assignment policy for execution units, i.e. containers and native processes.  
 |Field|Type|Optional|Default|Description|
 |---|---|---|---|---|
-|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`none`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
-|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`asc`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
+|pack_group|[PackGroup](#packgroup)|:white_check_mark:|`PackGroup.NO_PACK`|    Specifies the policy of CPU selection, whether in the same NUMA, same Package,     can cross packages, or distant. |
+|cpu_order|[CpuOrder](#cpuorder)|:white_check_mark:|`CpuOrder.ASC`|    Specifies the assignment order, whether ascending to starting for CPU lowest index,     or descending starting from the highest CPU index.     This configuration is ignored if pack_group is distant. |
 |one_cpu_per_core|bool|:white_check_mark:|`False`|    Whether to use only one CPU from each Core. This is relevant to hyper-threading     when multiple CPUs share the same core. When set to true, from each core only     the first CPU is considered. |
 ## MonitorType
 Monitors are used to monitor performance. They can be used to analyze the behavior of the benchmarks.  <br/>Supported values:


### PR DESCRIPTION
Add a new latency on for sysbench tests:

-  Sysbench output latency for mariaDB/MySQL using min/max/avg/95percentile.
    Add a graph to report latency.

- at bm_visualize: convert plot_chart into a class, to allow adding more plots at the same figure, while preserving the original function;

- fix min_max graph, which was producing wrong results when there was just 3 points: min/max/(avg or percentile).

With this patch, the graph is properly displaying latency 95th percentile with sysbench:

<img width="1500" height="1200" alt="image" src="https://github.com/user-attachments/assets/038ac574-51d5-4c35-85bd-4e9cc1b9f66a" />

