### PR TITLE
[bm-runner] Remove directory env vars.

### DIFF
--- a/bm-runner/config/adapter.py
+++ b/bm-runner/config/adapter.py
@@ -5,10 +5,11 @@ import subprocess
 from typing import Optional
 from pathlib import Path
 from bm_utils import ensure_exists
+from bm_utils import resolve_path
 
 
 class Adapter(dict):
-    ENV_VAR = "CSB_ADAPTERS"
+    DIR = "scripts/adapters"
 
     def __init__(self, name: str, path: Optional[Path] = None):
         """
@@ -28,7 +29,7 @@ class Adapter(dict):
         -
         """
         super().__init__(name=name, path=path)
-        self.fname = ensure_exists(name, path, self.ENV_VAR)
+        self.fname = ensure_exists(name, dir=resolve_path(self.DIR) if path is None else path)
 
     def adapt(self, output: str) -> str:
         # This is a blocking call

--- a/bm-runner/config/adapter.py
+++ b/bm-runner/config/adapter.py
@@ -9,7 +9,7 @@ from bm_utils import resolve_path
 
 
 class Adapter(dict):
-    DIR = "scripts/adapters"
+    DEFAULT_DIR = "scripts/adapters"  # relative to the project root
 
     def __init__(self, name: str, path: Optional[Path] = None):
         """
@@ -29,7 +29,8 @@ class Adapter(dict):
         -
         """
         super().__init__(name=name, path=path)
-        self.fname = ensure_exists(name, dir=resolve_path(self.DIR) if path is None else path)
+        self.default_abs_dir = resolve_path(self.DEFAULT_DIR)
+        self.fname = ensure_exists(name, dir=self.default_abs_dir if path is None else path)
 
     def adapt(self, output: str) -> str:
         # This is a blocking call

--- a/bm-runner/config/plugin.py
+++ b/bm-runner/config/plugin.py
@@ -32,7 +32,7 @@ class ExecutionTime(str, Enum):
 # "plugins" : [ { path: "<valid path>", name: "<script_name>", exec_time = "pre", args = ["1", "2"]}]
 # note that `args` has to be a list of strings
 class Plugin(dict):
-    DIR = "scripts/plugins"
+    DEFAULT_DIR = "scripts/plugins"  # relative to the project root
     CONFIG_KEY: str = "plugins"
 
     def __init__(
@@ -73,7 +73,8 @@ class Plugin(dict):
         self.exec_time = exec_time
         self.force_stop = force_stop
         self.process = None
-        self.fname = ensure_exists(name, dir=resolve_path(self.DIR) if path is None else path)
+        self.default_abs_dir = resolve_path(self.DEFAULT_DIR)
+        self.fname = ensure_exists(name, dir=self.default_abs_dir if path is None else path)
 
     def get_command(self) -> str:
         commands = [self.fname]

--- a/bm-runner/config/plugin.py
+++ b/bm-runner/config/plugin.py
@@ -5,6 +5,7 @@ from enum import Enum
 import sys
 from typing import Optional
 from bm_utils import ensure_exists
+from bm_utils import resolve_path
 from pathlib import Path
 from utils.process import BackgroundProcess
 
@@ -31,7 +32,7 @@ class ExecutionTime(str, Enum):
 # "plugins" : [ { path: "<valid path>", name: "<script_name>", exec_time = "pre", args = ["1", "2"]}]
 # note that `args` has to be a list of strings
 class Plugin(dict):
-    ENV_VAR = "CSB_PLUGINS"
+    DIR = "scripts/plugins"
     CONFIG_KEY: str = "plugins"
 
     def __init__(
@@ -72,7 +73,7 @@ class Plugin(dict):
         self.exec_time = exec_time
         self.force_stop = force_stop
         self.process = None
-        self.fname = ensure_exists(name, dir=path, env_var_dir=self.ENV_VAR)
+        self.fname = ensure_exists(name, dir=resolve_path(self.DIR) if path is None else path)
 
     def get_command(self) -> str:
         commands = [self.fname]

--- a/bm-runner/monitors/perf.py
+++ b/bm-runner/monitors/perf.py
@@ -6,13 +6,14 @@ import sys
 import subprocess
 import glob
 from monitors.monitor import Monitor
+from bm_utils import resolve_path
 from utils.logger import bm_log, LogType
 from utils.process import BackgroundProcess
 from config.env_config import EnvUniversalConfig, UniversalConfig
 
 
 class FlameGraph(Monitor):
-    FG_PATH_ENV_VAR_NAME = "FLAMEGRAPH"
+    FG_PATH_DIR = "deps/FlameGraph"
     ARM_SPE_PERIOD_ENV_VAR_NAME = "CSB_ARM_SPE_PERIOD"
     ARM_SPE_DEVICE_GLOB = "/sys/bus/event_source/devices/arm_spe*"
     ARM_SPE_MIN_INTERVAL_GLOB = "/sys/bus/event_source/devices/arm_spe*/caps/min_interval"
@@ -34,13 +35,7 @@ class FlameGraph(Monitor):
             requires=["perf"],
             pin=self.get_cpus(),
         )
-        self.fg_path = os.getenv(self.FG_PATH_ENV_VAR_NAME)
-        if self.fg_path is None:
-            bm_log(
-                f"{self.FG_PATH_ENV_VAR_NAME} environment variable is not set. Set it to the path of `stackcollapse-perf.pl` and try again. Or remove perf from monitors",
-                LogType.FATAL,
-            )
-            sys.exit(1)
+        self.fg_path = resolve_path(self.FG_PATH_DIR)
 
     @classmethod
     def perf_record_cmd(cls, args: list[str]) -> list[str]:

--- a/helpers/replot-all.py
+++ b/helpers/replot-all.py
@@ -72,10 +72,6 @@ def main():
     print(f"Using venv at {VENV_PATH}")
 
     # Set required env variables for CSB to run
-    env["FLAMEGRAPH"] = f"{SRC_DIR}/deps/FlameGraph"
-    env["SHE_HULK_ADAPTERS"] = f"{SRC_DIR}/scripts/adapters"
-    env["CSB_ADAPTERS"] = f"{SRC_DIR}/scripts/adapters"
-    env["CSB_PLUGINS"] = f"{SRC_DIR}/scripts/plugins"
     env["CSB_NO_BUILD_BENCH"] = "ON"
 
     # Get a list of CSV files

--- a/scripts/run-single.sh
+++ b/scripts/run-single.sh
@@ -17,12 +17,6 @@ TITLE=$(basename "$CONFIG" .json)
 
 ## this script is to be embedded in other scripts
 HOSTNAME=$(hostname)
-
-# Infer the important dirs
-export FLAMEGRAPH="${SCRIPT_DIR}/deps/FlameGraph"
-export SHE_HULK_ADAPTERS="${SCRIPT_DIR}/scripts/adapters"
-export CSB_ADAPTERS="${SCRIPT_DIR}/scripts/adapters"
-export CSB_PLUGINS="${SCRIPT_DIR}/scripts/plugins"
 export CSB_NO_BUILD_BENCH=ON
 
 BM_DIR=bm-runner


### PR DESCRIPTION
Change

- use `resolve_path` to locate folders under `csb`.
  no longer rely on env vars being set to identify the folders.