### PR TITLE
[bm-runner] Freeze lib versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ dominate
 docker
 jsonpath_ng
 psutil
-pytest
-pytest-mock
+pytest==9.0.3
+pytest-mock==3.15.1


### PR DESCRIPTION
Fix

- require specific version of `pytest` and `pytest-mock`