### PR TITLE
[bm-runner] Add `iostat` as a monitor.

### DIFF
--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -15,6 +15,7 @@ from utils.logger import bm_log, LogType
 from benchkit.utils.types import PathType
 from utils.bm_builder import Builder
 import pandas as pd
+from typing import Any
 
 
 def resolve_path(path: PathType, use_in_container: bool = False) -> PathType:
@@ -318,6 +319,14 @@ def read_data_frame_from_csv(
         return df
     except Exception as e:
         bm_log(f"{e} on {file}", LogType.ERROR)
+        return None
+
+
+def str_to_json(string: str) -> Optional[dict[str, Any]]:
+    try:
+        return json.loads(string)
+    except json.JSONDecodeError as e:
+        bm_log(f"Given String is not a valid JSON. {e}", LogType.ERROR)
         return None
 
 

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -16,6 +16,7 @@ import math
 from benchkit.utils.dir import parentdir
 from config.plot import PlotConfig
 from config.plot import PlotType
+from monitors.iostat import IostatStats
 import time
 from pathlib import Path
 import re
@@ -536,6 +537,7 @@ def visualize_in_html(output_dir: Path, title: str, plots: list[PlotConfig]):
     hostname = data_frame["hostname"].unique()
     # we split the data-frame into multiple data frames to help with visualization
     data_frames = split_data_frame(data_frame)
+    IostatStats.dump_plots_for_tree(output_dir)
     # For each data frame we'll generate the related graphs
     # and print related information
     for key, df in data_frames.items():

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -16,7 +16,6 @@ import math
 from benchkit.utils.dir import parentdir
 from config.plot import PlotConfig
 from config.plot import PlotType
-from monitors.iostat import IostatStats
 import time
 from pathlib import Path
 import re
@@ -537,7 +536,6 @@ def visualize_in_html(output_dir: Path, title: str, plots: list[PlotConfig]):
     hostname = data_frame["hostname"].unique()
     # we split the data-frame into multiple data frames to help with visualization
     data_frames = split_data_frame(data_frame)
-    IostatStats.dump_plots_for_tree(output_dir)
     # For each data frame we'll generate the related graphs
     # and print related information
     for key, df in data_frames.items():

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -29,6 +29,7 @@ class MonitorType(str, Enum):
     ----------
     MPSTAT: Runs mpstat and generates related graphs.
     PERF: Runs perf and generates flame-graphs.
+    IOSTAT: Runs iostat -x and generates block-device graphs.
     REDIS_BENCHMARK: parses the output of redis_benchmark.
     SAR_NET: monitors network traffic.
     PERF_STAT: Runs perf stat.
@@ -37,6 +38,7 @@ class MonitorType(str, Enum):
 
     MPSTAT = "mpstat"
     PERF = "perf"
+    IOSTAT = "iostat"
     REDIS_BENCHMARK = "redis_benchmark"
     SAR_NET = "sar_net"
     PERF_STAT = "perf_stat"

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -1,0 +1,198 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from pandas import DataFrame
+
+from monitors.monitor import Monitor
+from utils.logger import LogType, bm_log
+from utils.process import BackgroundProcess
+
+
+class IostatStats(Monitor):
+    INTERVAL = 1
+    OUTPUT_FILE = "iostat.json"
+    DEVICE_COL = "disk_device"
+    TIME_COL = "time"
+
+    PLOTSETS = [
+        ("I/O operations per second", "iostat-iops", ["r/s", "w/s", "d/s", "f/s"]),
+        ("Throughput (kB/s)", "iostat-throughput", ["rkB/s", "wkB/s", "dkB/s"]),
+        ("Await time (ms)", "iostat-await", ["r_await", "w_await", "d_await", "f_await"]),
+        ("Request size (kB)", "iostat-request-size", ["rareq-sz", "wareq-sz", "dareq-sz"]),
+        ("Average queue size", "iostat-queue", ["aqu-sz"]),
+        ("Utilization percentage", "iostat-util", ["util"]),
+        ("Merge rate", "iostat-merge-rate", ["rrqm/s", "wrqm/s", "drqm/s"]),
+        ("Merge percentage", "iostat-merge-percent", ["rrqm", "wrqm", "drqm"]),
+    ]
+
+    def __init__(self, output_dir: str, args: Optional[list[str]] = None):
+        if args is None:
+            args = []
+        super().__init__(dir=output_dir, args=args)
+        self.stat = BackgroundProcess(
+            name="iostat",
+            ofile_name=self.OUTPUT_FILE,
+            cmds=self.iostat_cmd(args),
+            out_dir=output_dir,
+            requires=["iostat"],
+            pin=self.get_cpus(),
+        )
+
+    @classmethod
+    def iostat_cmd(cls, args: list[str]) -> list[str]:
+        cmds = ["iostat", "-x", "-o", "JSON", "-y"]
+        cmds.extend(args)
+        cmds.append(str(cls.INTERVAL))
+        return cmds
+
+    def start(self):
+        self.stat.start()
+
+    def stop(self):
+        self.stat.stop()
+        self.dump_plots_from_file(Path(self.dir) / self.OUTPUT_FILE)
+
+    def collect_results(self) -> str:
+        data = self.__read_output()
+        if data is None:
+            return ""
+        return self.aggregate_results(self.dataframe_from_json(data))
+
+    def __read_output(self) -> Optional[dict[str, Any]]:
+        try:
+            return json.loads(self.stat.read_output())
+        except json.JSONDecodeError as e:
+            bm_log(f"Could not read iostat output as JSON {e}", LogType.ERROR)
+            return None
+
+    @classmethod
+    def dataframe_from_json(cls, data: dict[str, Any]) -> DataFrame:
+        rows = []
+        statistics = cls._statistics(data)
+        for sample_idx, stat in enumerate(statistics):
+            for disk in stat.get("disk", []):
+                row = dict(disk)
+                row[cls.TIME_COL] = sample_idx * cls.INTERVAL
+                rows.append(row)
+        return pd.DataFrame(rows)
+
+    @classmethod
+    def aggregate_results(cls, df: DataFrame) -> str:
+        if df.empty or cls.DEVICE_COL not in df:
+            return ""
+
+        results = []
+        metric_cols = cls.metric_columns(df)
+        for device, device_df in df.groupby(cls.DEVICE_COL):
+            means = device_df[metric_cols].mean(numeric_only=True)
+            device_name = cls.safe_name(str(device))
+            for metric, value in means.items():
+                results.append(f"iostat_{device_name}_{cls.safe_name(metric)}={value}")
+        return ";".join(results) + (";" if results else "")
+
+    @classmethod
+    def dump_plots_for_tree(cls, output_dir: Path):
+        for json_file in glob_iostat_files(output_dir):
+            cls.dump_plots_from_file(json_file)
+
+    @classmethod
+    def dump_plots_from_file(cls, json_file: Path):
+        if not json_file.exists():
+            return
+
+        try:
+            with open(json_file, "r") as file:
+                data = json.load(file)
+        except (OSError, json.JSONDecodeError) as e:
+            bm_log(f"Could not read iostat output from {json_file}: {e}", LogType.ERROR)
+            return
+
+        cls.dump_plots(cls.dataframe_from_json(data), json_file.parent)
+
+    @classmethod
+    def dump_plots(cls, df: DataFrame, output_dir: Path):
+        if df.empty or cls.DEVICE_COL not in df:
+            return
+
+        df = cls.active_devices(df)
+        for title, fname, metrics in cls.PLOTSETS:
+            present_metrics = [metric for metric in metrics if metric in df.columns]
+            if not present_metrics:
+                continue
+            cls.dump_plot(df, title, present_metrics, output_dir / f"{fname}.png")
+
+    @classmethod
+    def dump_plot(cls, df: DataFrame, title: str, metrics: list[str], filename: Path):
+        plot_df = df[[cls.TIME_COL, cls.DEVICE_COL] + metrics].copy()
+        melted = plot_df.melt(
+            id_vars=[cls.TIME_COL, cls.DEVICE_COL],
+            value_vars=metrics,
+            var_name="metric",
+            value_name="value",
+        )
+        melted["series"] = melted[cls.DEVICE_COL].astype(str) + " " + melted["metric"]
+        wide = melted.pivot_table(
+            index=cls.TIME_COL, columns="series", values="value", aggfunc="mean"
+        )
+
+        wide.plot()
+        plt.title(title)
+        plt.xlabel("Seconds Elapsed")
+        plt.grid(True)
+        plt.legend(
+            loc="upper left",
+            bbox_to_anchor=(1, 1),
+            borderaxespad=0.3,
+            fontsize=4.5,
+        )
+        plt.tight_layout()
+        plt.savefig(filename)
+        plt.close()
+
+    @classmethod
+    def active_devices(cls, df: DataFrame) -> DataFrame:
+        activity_metrics = [
+            metric
+            for metric in ["r/s", "w/s", "d/s", "f/s", "rkB/s", "wkB/s", "dkB/s", "util", "aqu-sz"]
+            if metric in df.columns
+        ]
+        if not activity_metrics:
+            return df
+
+        active_rows = df[activity_metrics].abs().sum(axis=1) > 0
+        active_devices = df.loc[active_rows, cls.DEVICE_COL].unique()
+        if len(active_devices) == 0:
+            return df
+        return df[df[cls.DEVICE_COL].isin(active_devices)]
+
+    @classmethod
+    def metric_columns(cls, df: DataFrame) -> list[str]:
+        return [
+            col
+            for col in df.columns
+            if col not in [cls.DEVICE_COL, cls.TIME_COL]
+            and pd.api.types.is_numeric_dtype(df[col])
+        ]
+
+    @staticmethod
+    def safe_name(name: str) -> str:
+        return re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_")
+
+    @staticmethod
+    def _statistics(data: dict[str, Any]) -> list[dict[str, Any]]:
+        try:
+            return data["sysstat"]["hosts"][0]["statistics"]
+        except (KeyError, IndexError, TypeError):
+            bm_log("iostat JSON does not contain sysstat.hosts[0].statistics", LogType.ERROR)
+            return []
+
+
+def glob_iostat_files(output_dir: Path) -> list[Path]:
+    return sorted(output_dir.glob(f"**/{IostatStats.OUTPUT_FILE}"))

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -1,7 +1,6 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import json
 import re
 from pathlib import Path
 from typing import Any
@@ -52,13 +51,14 @@ class IoStat(Monitor):
 
     def stop(self):
         self.stat.stop()
-        self.dump_plots_from_file(Path(self.stat.output_file_name))
 
     def collect_results(self) -> str:
         data = str_to_json(self.stat.read_output())
         if data is None:
             return ""
-        return self.aggregate_results(self.dataframe_from_json(data))
+        dataframe = self.dataframe_from_json(data)
+        self.dump_plots(dataframe, self.dir)
+        return self.aggregate_results(dataframe)
 
     @classmethod
     def dataframe_from_json(cls, data: dict[str, Any]) -> DataFrame:
@@ -84,20 +84,6 @@ class IoStat(Monitor):
             for metric, value in means.items():
                 results.append(f"iostat_{device_name}_{cls.safe_name(metric)}={value}")
         return ";".join(results) + (";" if results else "")
-
-    @classmethod
-    def dump_plots_from_file(cls, json_file: Path):
-        if not json_file.exists():
-            return
-
-        try:
-            with open(json_file, "r") as file:
-                data = json.load(file)
-        except (OSError, json.JSONDecodeError) as e:
-            bm_log(f"Could not read iostat output from {json_file}: {e}", LogType.ERROR)
-            return
-
-        cls.dump_plots(cls.dataframe_from_json(data), json_file.parent)
 
     @classmethod
     def dump_plots(cls, df: DataFrame, output_dir: Path):

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -56,14 +56,14 @@ class IoStat(Monitor):
         data = str_to_json(self.stat.read_output())
         if data is None:
             return ""
-        dataframe = self.dataframe_from_json(data)
+        dataframe = self.__transform_json_to_df(data)
         self.dump_plots(dataframe, self.dir)
         return self.aggregate_results(dataframe)
 
     @classmethod
-    def dataframe_from_json(cls, data: dict[str, Any]) -> DataFrame:
+    def __transform_json_to_df(cls, data: dict[str, Any]) -> DataFrame:
         rows = []
-        statistics = cls._statistics(data)
+        statistics = cls.__get_statistics(data)
         for sample_idx, stat in enumerate(statistics):
             for disk in stat.get("disk", []):
                 row = dict(disk)
@@ -147,7 +147,7 @@ class IoStat(Monitor):
         return re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_")
 
     @staticmethod
-    def _statistics(data: dict[str, Any]) -> list[dict[str, Any]]:
+    def __get_statistics(data: dict[str, Any]) -> list[dict[str, Any]]:
         try:
             return data["sysstat"]["hosts"][0]["statistics"]
         except (KeyError, IndexError, TypeError):

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -58,9 +58,10 @@ class IoStat(Monitor):
         if data is not None:
             dataframe = self.__transform_json_to_df(data)
             if not dataframe.empty and self.DEVICE_COL in dataframe.columns:
+                mean_output = self.__get_metric_means(dataframe)
+                # filter out inactive devices for the plots
                 dataframe = self.__remove_inactive_devices(dataframe)
                 self.__dump_plots(dataframe)
-                mean_output = self.__get_metric_means(dataframe)
         return mean_output
 
     @classmethod

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -53,13 +53,15 @@ class IoStat(Monitor):
         self.stat.stop()
 
     def collect_results(self) -> str:
+        mean_output = ""
         data = str_to_json(self.stat.read_output())
-        if data is None:
-            return ""
-        dataframe = self.__transform_json_to_df(data)
-        dataframe = self.__remove_inactive_devices(dataframe)
-        self.__dump_plots(dataframe)
-        return self.aggregate_results(dataframe)
+        if data is not None:
+            dataframe = self.__transform_json_to_df(data)
+            if not dataframe.empty and self.DEVICE_COL in dataframe.columns:
+                dataframe = self.__remove_inactive_devices(dataframe)
+                self.__dump_plots(dataframe)
+                mean_output = self.__get_metric_means(dataframe)
+        return mean_output
 
     @classmethod
     def __transform_json_to_df(cls, data: dict[str, Any]) -> DataFrame:
@@ -72,23 +74,21 @@ class IoStat(Monitor):
                 rows.append(row)
         return pd.DataFrame(rows)
 
-    @classmethod
-    def aggregate_results(cls, df: DataFrame) -> str:
-        if df.empty or cls.DEVICE_COL not in df:
-            return ""
+    def __get_metric_means(self, df: DataFrame) -> str:
+        output = ""
+        metric_cols = self.__get_numeric_columns(df)
+        # group by device name, and calculate means
+        means_by_device = df.groupby(self.DEVICE_COL)[metric_cols].mean(numeric_only=True)
+        # iterate and for each device dump key_value names
+        for device, row in means_by_device.iterrows():
+            device_name = self.__sanitize_name(str(device))
+            for metric, value in row.items():
+                key = f"{self.name}_{device_name}_{self.__sanitize_name(metric)}"
+                output += f"{key}={value};"
 
-        results = []
-        metric_cols = cls.metric_columns(df)
-        for device, device_df in df.groupby(cls.DEVICE_COL):
-            means = device_df[metric_cols].mean(numeric_only=True)
-            device_name = cls.safe_name(str(device))
-            for metric, value in means.items():
-                results.append(f"iostat_{device_name}_{cls.safe_name(metric)}={value}")
-        return ";".join(results) + (";" if results else "")
+        return output
 
     def __dump_plots(self, df: DataFrame):
-        if df.empty or self.DEVICE_COL not in df:
-            return
         for plot_title, plot_name, metrics in self.PLOT_SETS:
             # only consider present columns
             columns = [metric for metric in metrics if metric in df.columns]
@@ -140,7 +140,7 @@ class IoStat(Monitor):
         return df
 
     @classmethod
-    def metric_columns(cls, df: DataFrame) -> list[str]:
+    def __get_numeric_columns(cls, df: DataFrame) -> list[str]:
         return [
             col
             for col in df.columns
@@ -148,7 +148,7 @@ class IoStat(Monitor):
         ]
 
     @staticmethod
-    def safe_name(name: str) -> str:
+    def __sanitize_name(name: str) -> str:
         return re.sub(r"[^0-9A-Za-z]+", "_", name).strip("_")
 
     @staticmethod

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -15,7 +15,7 @@ from utils.process import BackgroundProcess
 from bm_visualize import plot_chart, PlotConfig, PlotType
 
 
-class IostatStats(Monitor):
+class IoStat(Monitor):
     INTERVAL = 1
     OUTPUT_FILE = "iostat.json"
     DEVICE_COL = "disk_device"

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -177,8 +177,7 @@ class IostatStats(Monitor):
         return [
             col
             for col in df.columns
-            if col not in [cls.DEVICE_COL, cls.TIME_COL]
-            and pd.api.types.is_numeric_dtype(df[col])
+            if col not in [cls.DEVICE_COL, cls.TIME_COL] and pd.api.types.is_numeric_dtype(df[col])
         ]
 
     @staticmethod

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -4,7 +4,7 @@
 import json
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 from pandas import DataFrame
@@ -13,11 +13,11 @@ from monitors.monitor import Monitor
 from utils.logger import LogType, bm_log
 from utils.process import BackgroundProcess
 from bm_visualize import plot_chart, PlotConfig, PlotType
+from bm_utils import str_to_json
 
 
 class IoStat(Monitor):
     INTERVAL = 1
-    OUTPUT_FILE = "iostat.json"
     DEVICE_COL = "disk_device"
     TIME_COL = "time"
 
@@ -32,45 +32,33 @@ class IoStat(Monitor):
         ("Merge percentage", "iostat-merge-percent", ["rrqm", "wrqm", "drqm"]),
     ]
 
-    def __init__(self, output_dir: str, args: Optional[list[str]] = None):
-        if args is None:
-            args = []
+    def __init__(self, output_dir: str, args: list[str] = []):
         super().__init__(dir=output_dir, args=args)
+        cmds = ["iostat", "-x", "-o", "JSON", "-y"]
+        cmds.extend(args)
+        cmds.append(str(self.INTERVAL))
+        self.name = "iostat"
         self.stat = BackgroundProcess(
-            name="iostat",
-            ofile_name=self.OUTPUT_FILE,
-            cmds=self.iostat_cmd(args),
+            name=self.name,
+            ofile_name=f"{self.name}.json",
+            cmds=cmds,
             out_dir=output_dir,
             requires=["iostat"],
             pin=self.get_cpus(),
         )
-
-    @classmethod
-    def iostat_cmd(cls, args: list[str]) -> list[str]:
-        cmds = ["iostat", "-x", "-o", "JSON", "-y"]
-        cmds.extend(args)
-        cmds.append(str(cls.INTERVAL))
-        return cmds
 
     def start(self):
         self.stat.start()
 
     def stop(self):
         self.stat.stop()
-        self.dump_plots_from_file(Path(self.dir) / self.OUTPUT_FILE)
+        self.dump_plots_from_file(Path(self.stat.output_file_name))
 
     def collect_results(self) -> str:
-        data = self.__read_output()
+        data = str_to_json(self.stat.read_output())
         if data is None:
             return ""
         return self.aggregate_results(self.dataframe_from_json(data))
-
-    def __read_output(self) -> Optional[dict[str, Any]]:
-        try:
-            return json.loads(self.stat.read_output())
-        except json.JSONDecodeError as e:
-            bm_log(f"Could not read iostat output as JSON {e}", LogType.ERROR)
-            return None
 
     @classmethod
     def dataframe_from_json(cls, data: dict[str, Any]) -> DataFrame:

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -98,11 +98,6 @@ class IostatStats(Monitor):
         return ";".join(results) + (";" if results else "")
 
     @classmethod
-    def dump_plots_for_tree(cls, output_dir: Path):
-        for json_file in glob_iostat_files(output_dir):
-            cls.dump_plots_from_file(json_file)
-
-    @classmethod
     def dump_plots_from_file(cls, json_file: Path):
         if not json_file.exists():
             return
@@ -191,7 +186,3 @@ class IostatStats(Monitor):
         except (KeyError, IndexError, TypeError):
             bm_log("iostat JSON does not contain sysstat.hosts[0].statistics", LogType.ERROR)
             return []
-
-
-def glob_iostat_files(output_dir: Path) -> list[Path]:
-    return sorted(output_dir.glob(f"**/{IostatStats.OUTPUT_FILE}"))

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -90,7 +90,7 @@ class IoStat(Monitor):
         if df.empty or cls.DEVICE_COL not in df:
             return
 
-        df = cls.active_devices(df)
+        df = cls.__remove_inactive_devices(df)
         for title, fname, metrics in cls.PLOTSETS:
             present_metrics = [metric for metric in metrics if metric in df.columns]
             if not present_metrics:
@@ -119,20 +119,26 @@ class IoStat(Monitor):
         plot_chart(df=melted, plot=cfg, out_fig_name=filename)
 
     @classmethod
-    def active_devices(cls, df: DataFrame) -> DataFrame:
+    def __remove_inactive_devices(cls, df: DataFrame) -> DataFrame:
+        """
+        Removes devices that were never active during the run.
+        """
+        # check which metrics exist in the data frame, and keep those columns
         activity_metrics = [
             metric
             for metric in ["r/s", "w/s", "d/s", "f/s", "rkB/s", "wkB/s", "dkB/s", "util", "aqu-sz"]
             if metric in df.columns
         ]
-        if not activity_metrics:
-            return df
+        if len(activity_metrics) > 0:
+            # Row-wise activity check: sum selected metrics and mark rows whose total activity > 0
+            active_rows = df[activity_metrics].abs().sum(axis=1) > 0
+            # Extract the set of devices associated with active rows
+            active_devices = df.loc[active_rows, cls.DEVICE_COL].unique()
+            if len(active_devices) > 0:
+                # keep those devices that has been active at least once.
+                return df[df[cls.DEVICE_COL].isin(active_devices)]
 
-        active_rows = df[activity_metrics].abs().sum(axis=1) > 0
-        active_devices = df.loc[active_rows, cls.DEVICE_COL].unique()
-        if len(active_devices) == 0:
-            return df
-        return df[df[cls.DEVICE_COL].isin(active_devices)]
+        return df
 
     @classmethod
     def metric_columns(cls, df: DataFrame) -> list[str]:

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -6,13 +6,13 @@ import re
 from pathlib import Path
 from typing import Any, Optional
 
-import matplotlib.pyplot as plt
 import pandas as pd
 from pandas import DataFrame
 
 from monitors.monitor import Monitor
 from utils.logger import LogType, bm_log
 from utils.process import BackgroundProcess
+from bm_visualize import plot_chart, PlotConfig, PlotType
 
 
 class IostatStats(Monitor):
@@ -121,7 +121,7 @@ class IostatStats(Monitor):
             present_metrics = [metric for metric in metrics if metric in df.columns]
             if not present_metrics:
                 continue
-            cls.dump_plot(df, title, present_metrics, output_dir / f"{fname}.png")
+            cls.dump_plot(df, title, present_metrics, output_dir / f"{fname}")
 
     @classmethod
     def dump_plot(cls, df: DataFrame, title: str, metrics: list[str], filename: Path):
@@ -133,23 +133,16 @@ class IostatStats(Monitor):
             value_name="value",
         )
         melted["series"] = melted[cls.DEVICE_COL].astype(str) + " " + melted["metric"]
-        wide = melted.pivot_table(
-            index=cls.TIME_COL, columns="series", values="value", aggfunc="mean"
+        cfg = PlotConfig(
+            x=cls.TIME_COL,
+            title=title,
+            x_lbl="Seconds Elapsed",
+            y="value",
+            hue="series",
+            hue_lbl="Device/metric",
+            type=PlotType.MEAN,
         )
-
-        wide.plot()
-        plt.title(title)
-        plt.xlabel("Seconds Elapsed")
-        plt.grid(True)
-        plt.legend(
-            loc="upper left",
-            bbox_to_anchor=(1, 1),
-            borderaxespad=0.3,
-            fontsize=4.5,
-        )
-        plt.tight_layout()
-        plt.savefig(filename)
-        plt.close()
+        plot_chart(df=melted, plot=cfg, out_fig_name=filename)
 
     @classmethod
     def active_devices(cls, df: DataFrame) -> DataFrame:

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import re
-from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -13,22 +12,23 @@ from utils.logger import LogType, bm_log
 from utils.process import BackgroundProcess
 from bm_visualize import plot_chart, PlotConfig, PlotType
 from bm_utils import str_to_json
+import os
 
 
 class IoStat(Monitor):
     INTERVAL = 1
     DEVICE_COL = "disk_device"
     TIME_COL = "time"
-
-    PLOTSETS = [
-        ("I/O operations per second", "iostat-iops", ["r/s", "w/s", "d/s", "f/s"]),
-        ("Throughput (kB/s)", "iostat-throughput", ["rkB/s", "wkB/s", "dkB/s"]),
-        ("Await time (ms)", "iostat-await", ["r_await", "w_await", "d_await", "f_await"]),
-        ("Request size (kB)", "iostat-request-size", ["rareq-sz", "wareq-sz", "dareq-sz"]),
-        ("Average queue size", "iostat-queue", ["aqu-sz"]),
-        ("Utilization percentage", "iostat-util", ["util"]),
-        ("Merge rate", "iostat-merge-rate", ["rrqm/s", "wrqm/s", "drqm/s"]),
-        ("Merge percentage", "iostat-merge-percent", ["rrqm", "wrqm", "drqm"]),
+    # plot title, plot file name, columns/metrics to be plotted together
+    PLOT_SETS = [
+        ("I/O operations per second", "iops", ["r/s", "w/s", "d/s", "f/s"]),
+        ("Throughput (kB/s)", "throughput", ["rkB/s", "wkB/s", "dkB/s"]),
+        ("Await time (ms)", "await", ["r_await", "w_await", "d_await", "f_await"]),
+        ("Request size (kB)", "request-size", ["rareq-sz", "wareq-sz", "dareq-sz"]),
+        ("Average queue size", "avg-queue-size", ["aqu-sz"]),
+        ("Utilization percentage", "utilization-percent", ["util"]),
+        ("Merge rate", "merge-rate", ["rrqm/s", "wrqm/s", "drqm/s"]),
+        ("Merge percentage", "merge-percent", ["rrqm", "wrqm", "drqm"]),
     ]
 
     def __init__(self, output_dir: str, args: list[str] = []):
@@ -57,7 +57,8 @@ class IoStat(Monitor):
         if data is None:
             return ""
         dataframe = self.__transform_json_to_df(data)
-        self.dump_plots(dataframe, self.dir)
+        dataframe = self.__remove_inactive_devices(dataframe)
+        self.__dump_plots(dataframe)
         return self.aggregate_results(dataframe)
 
     @classmethod
@@ -85,38 +86,36 @@ class IoStat(Monitor):
                 results.append(f"iostat_{device_name}_{cls.safe_name(metric)}={value}")
         return ";".join(results) + (";" if results else "")
 
-    @classmethod
-    def dump_plots(cls, df: DataFrame, output_dir: Path):
-        if df.empty or cls.DEVICE_COL not in df:
+    def __dump_plots(self, df: DataFrame):
+        if df.empty or self.DEVICE_COL not in df:
             return
+        for plot_title, plot_name, metrics in self.PLOT_SETS:
+            # only consider present columns
+            columns = [metric for metric in metrics if metric in df.columns]
+            if len(columns) > 0:
+                self.__dump_plot(df, plot_title, columns, plot_name)
 
-        df = cls.__remove_inactive_devices(df)
-        for title, fname, metrics in cls.PLOTSETS:
-            present_metrics = [metric for metric in metrics if metric in df.columns]
-            if not present_metrics:
-                continue
-            cls.dump_plot(df, title, present_metrics, output_dir / f"{fname}")
-
-    @classmethod
-    def dump_plot(cls, df: DataFrame, title: str, metrics: list[str], filename: Path):
-        plot_df = df[[cls.TIME_COL, cls.DEVICE_COL] + metrics].copy()
+    def __dump_plot(self, df: DataFrame, plot_title: str, columns: list[str], plot_name: str):
+        plot_df = df[[self.TIME_COL, self.DEVICE_COL] + columns].copy()
         melted = plot_df.melt(
-            id_vars=[cls.TIME_COL, cls.DEVICE_COL],
-            value_vars=metrics,
+            id_vars=[self.TIME_COL, self.DEVICE_COL],
+            value_vars=columns,
             var_name="metric",
             value_name="value",
         )
-        melted["series"] = melted[cls.DEVICE_COL].astype(str) + " " + melted["metric"]
+        melted["series"] = melted[self.DEVICE_COL].astype(str) + " " + melted["metric"]
         cfg = PlotConfig(
-            x=cls.TIME_COL,
-            title=title,
+            x=self.TIME_COL,
+            title=plot_title,
             x_lbl="Seconds Elapsed",
             y="value",
             hue="series",
             hue_lbl="Device/metric",
             type=PlotType.MEAN,
         )
-        plot_chart(df=melted, plot=cfg, out_fig_name=filename)
+        plot_chart(
+            df=melted, plot=cfg, out_fig_name=os.path.join(self.dir, f"{self.name}-{plot_name}")
+        )
 
     @classmethod
     def __remove_inactive_devices(cls, df: DataFrame) -> DataFrame:

--- a/bm-runner/monitors/monitor_factory.py
+++ b/bm-runner/monitors/monitor_factory.py
@@ -5,6 +5,7 @@ from config.benchmark import MonitorType
 from monitors.mpstat import SystemStats
 from monitors.redis_bench import RedisStats
 from monitors.perf import FlameGraph
+from monitors.iostat import IostatStats
 from monitors.sarnet import SarNetStats
 from monitors.monitor import Monitor
 from monitors.perfstat import PerfStat
@@ -47,6 +48,8 @@ class MonitorFactory:
                 return SystemStats(output_dir=results_dir, args=args)
             case MonitorType.PERF:
                 return FlameGraph(output_dir=results_dir, args=args)
+            case MonitorType.IOSTAT:
+                return IostatStats(output_dir=results_dir, args=args)
             case MonitorType.REDIS_BENCHMARK:
                 return RedisStats(output_dir=results_dir, args=args)
             case MonitorType.SAR_NET:

--- a/bm-runner/monitors/monitor_factory.py
+++ b/bm-runner/monitors/monitor_factory.py
@@ -5,7 +5,7 @@ from config.benchmark import MonitorType
 from monitors.mpstat import SystemStats
 from monitors.redis_bench import RedisStats
 from monitors.perf import FlameGraph
-from monitors.iostat import IostatStats
+from monitors.iostat import IoStat
 from monitors.sarnet import SarNetStats
 from monitors.monitor import Monitor
 from monitors.perfstat import PerfStat
@@ -49,7 +49,7 @@ class MonitorFactory:
             case MonitorType.PERF:
                 return FlameGraph(output_dir=results_dir, args=args)
             case MonitorType.IOSTAT:
-                return IostatStats(output_dir=results_dir, args=args)
+                return IoStat(output_dir=results_dir, args=args)
             case MonitorType.REDIS_BENCHMARK:
                 return RedisStats(output_dir=results_dir, args=args)
             case MonitorType.SAR_NET:

--- a/bm-runner/monitors/mpstat.py
+++ b/bm-runner/monitors/mpstat.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 import os
-import json
 import pandas as pd
 import matplotlib.pyplot as plt
 from jsonpath_ng import parse
 from monitors.monitor import Monitor
 from utils.logger import bm_log, LogType
-from typing import Optional
 from utils.process import BackgroundProcess
+from bm_utils import str_to_json
 
 
 class SystemStats(Monitor):
@@ -83,16 +82,9 @@ class SystemStats(Monitor):
         ).reset_index()
         return self.transform(df)
 
-    def __read_output(self) -> Optional[dict]:
-        try:
-            return json.loads(self.stat.read_output())
-        except json.JSONDecodeError as e:
-            bm_log(f"Could not read mpstat output as JSON {e}")
-            return None
-
     def collect_results(self) -> str:
         if self.stat:
-            data = self.__read_output()
+            data = str_to_json(self.stat.read_output())
             if data:
                 self.dump_plot(data)
                 results = self.get_cpu_load(data)

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -1,0 +1,105 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import json
+
+from monitors.iostat import IostatStats
+
+
+def iostat_sample():
+    return {
+        "sysstat": {
+            "hosts": [
+                {
+                    "statistics": [
+                        {
+                            "disk": [
+                                disk_sample("nvme0n1", 1.0),
+                                disk_sample("loop0", 0.0),
+                            ]
+                        },
+                        {
+                            "disk": [
+                                disk_sample("nvme0n1", 3.0),
+                                disk_sample("loop0", 0.0),
+                            ]
+                        },
+                    ]
+                }
+            ]
+        }
+    }
+
+
+def disk_sample(device, value):
+    return {
+        "disk_device": device,
+        "r/s": value,
+        "w/s": value + 1,
+        "d/s": value + 2,
+        "f/s": value + 3,
+        "rkB/s": value + 4,
+        "wkB/s": value + 5,
+        "dkB/s": value + 6,
+        "rrqm/s": value + 7,
+        "wrqm/s": value + 8,
+        "drqm/s": value + 9,
+        "rrqm": value + 10,
+        "wrqm": value + 11,
+        "drqm": value + 12,
+        "r_await": value + 13,
+        "w_await": value + 14,
+        "d_await": value + 15,
+        "f_await": value + 16,
+        "rareq-sz": value + 17,
+        "wareq-sz": value + 18,
+        "dareq-sz": value + 19,
+        "aqu-sz": value + 20,
+        "util": value + 21,
+    }
+
+
+def test_iostat_cmd_enforces_extended_json_output():
+    assert IostatStats.iostat_cmd(["nvme0n1"]) == [
+        "iostat",
+        "-x",
+        "-o",
+        "JSON",
+        "-y",
+        "nvme0n1",
+        "1",
+    ]
+
+
+def test_iostat_dataframe_from_json_flattens_samples():
+    df = IostatStats.dataframe_from_json(iostat_sample())
+
+    assert list(df["time"]) == [0, 0, 1, 1]
+    assert list(df["disk_device"]) == ["nvme0n1", "loop0", "nvme0n1", "loop0"]
+    assert list(df["r/s"]) == [1.0, 0.0, 3.0, 0.0]
+
+
+def test_iostat_aggregate_results_sanitizes_metric_names():
+    df = IostatStats.dataframe_from_json(iostat_sample())
+    results = IostatStats.aggregate_results(df)
+    entries = dict(item.split("=", maxsplit=1) for item in results.rstrip(";").split(";"))
+
+    assert float(entries["iostat_nvme0n1_r_s"]) == 2.0
+    assert float(entries["iostat_nvme0n1_rareq_sz"]) == 19.0
+    assert float(entries["iostat_loop0_util"]) == 21.0
+
+
+def test_iostat_dump_plots_for_tree_generates_plots_for_all_runs(tmp_path):
+    first_run = tmp_path / "container_cnt-1" / "run-1"
+    second_run = tmp_path / "container_cnt-2" / "run-1"
+    first_run.mkdir(parents=True)
+    second_run.mkdir(parents=True)
+    (first_run / IostatStats.OUTPUT_FILE).write_text(json.dumps(iostat_sample()))
+    (second_run / IostatStats.OUTPUT_FILE).write_text(json.dumps(iostat_sample()))
+
+    IostatStats.dump_plots_for_tree(tmp_path)
+
+    for run_dir in [first_run, second_run]:
+        assert (run_dir / "iostat-iops.png").stat().st_size > 0
+        assert (run_dir / "iostat-throughput.png").stat().st_size > 0
+        assert (run_dir / "iostat-util.png").stat().st_size > 0

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -58,18 +58,6 @@ def disk_sample(device, value):
     }
 
 
-def test_iostat_cmd_enforces_extended_json_output():
-    assert IoStat.iostat_cmd(["nvme0n1"]) == [
-        "iostat",
-        "-x",
-        "-o",
-        "JSON",
-        "-y",
-        "nvme0n1",
-        "1",
-    ]
-
-
 def test_iostat_dataframe_from_json_flattens_samples():
     df = IoStat.dataframe_from_json(iostat_sample())
 

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -1,7 +1,6 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import json
 
 from monitors.iostat import IostatStats
 
@@ -87,19 +86,3 @@ def test_iostat_aggregate_results_sanitizes_metric_names():
     assert float(entries["iostat_nvme0n1_r_s"]) == 2.0
     assert float(entries["iostat_nvme0n1_rareq_sz"]) == 19.0
     assert float(entries["iostat_loop0_util"]) == 21.0
-
-
-def test_iostat_dump_plots_for_tree_generates_plots_for_all_runs(tmp_path):
-    first_run = tmp_path / "container_cnt-1" / "run-1"
-    second_run = tmp_path / "container_cnt-2" / "run-1"
-    first_run.mkdir(parents=True)
-    second_run.mkdir(parents=True)
-    (first_run / IostatStats.OUTPUT_FILE).write_text(json.dumps(iostat_sample()))
-    (second_run / IostatStats.OUTPUT_FILE).write_text(json.dumps(iostat_sample()))
-
-    IostatStats.dump_plots_for_tree(tmp_path)
-
-    for run_dir in [first_run, second_run]:
-        assert (run_dir / "iostat-iops.png").stat().st_size > 0
-        assert (run_dir / "iostat-throughput.png").stat().st_size > 0
-        assert (run_dir / "iostat-util.png").stat().st_size > 0

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -59,16 +59,16 @@ def disk_sample(device, value):
 
 
 def test_iostat_dataframe_from_json_flattens_samples():
-    df = IoStat.__transform_json_to_df(iostat_sample())
-
+    df = IoStat._IoStat__transform_json_to_df(iostat_sample())  # type: ignore[unresolved-attribute]
     assert list(df["time"]) == [0, 0, 1, 1]
     assert list(df["disk_device"]) == ["nvme0n1", "loop0", "nvme0n1", "loop0"]
     assert list(df["r/s"]) == [1.0, 0.0, 3.0, 0.0]
 
 
 def test_iostat_aggregate_results_sanitizes_metric_names():
-    df = IoStat.__transform_json_to_df(iostat_sample())
-    results = IoStat.aggregate_results(df)
+    stat = IoStat("test", [])
+    df = IoStat._IoStat__transform_json_to_df(iostat_sample())  # type: ignore[unresolved-attribute]
+    results = stat._IoStat__get_metric_means(df)  # type: ignore[unresolved-attribute]
     entries = dict(item.split("=", maxsplit=1) for item in results.rstrip(";").split(";"))
 
     assert float(entries["iostat_nvme0n1_r_s"]) == 2.0

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -59,7 +59,7 @@ def disk_sample(device, value):
 
 
 def test_iostat_dataframe_from_json_flattens_samples():
-    df = IoStat.dataframe_from_json(iostat_sample())
+    df = IoStat.__transform_json_to_df(iostat_sample())
 
     assert list(df["time"]) == [0, 0, 1, 1]
     assert list(df["disk_device"]) == ["nvme0n1", "loop0", "nvme0n1", "loop0"]
@@ -67,7 +67,7 @@ def test_iostat_dataframe_from_json_flattens_samples():
 
 
 def test_iostat_aggregate_results_sanitizes_metric_names():
-    df = IoStat.dataframe_from_json(iostat_sample())
+    df = IoStat.__transform_json_to_df(iostat_sample())
     results = IoStat.aggregate_results(df)
     entries = dict(item.split("=", maxsplit=1) for item in results.rstrip(";").split(";"))
 

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 
-from monitors.iostat import IostatStats
+from monitors.iostat import IoStat
 
 
 def iostat_sample():
@@ -59,7 +59,7 @@ def disk_sample(device, value):
 
 
 def test_iostat_cmd_enforces_extended_json_output():
-    assert IostatStats.iostat_cmd(["nvme0n1"]) == [
+    assert IoStat.iostat_cmd(["nvme0n1"]) == [
         "iostat",
         "-x",
         "-o",
@@ -71,7 +71,7 @@ def test_iostat_cmd_enforces_extended_json_output():
 
 
 def test_iostat_dataframe_from_json_flattens_samples():
-    df = IostatStats.dataframe_from_json(iostat_sample())
+    df = IoStat.dataframe_from_json(iostat_sample())
 
     assert list(df["time"]) == [0, 0, 1, 1]
     assert list(df["disk_device"]) == ["nvme0n1", "loop0", "nvme0n1", "loop0"]
@@ -79,8 +79,8 @@ def test_iostat_dataframe_from_json_flattens_samples():
 
 
 def test_iostat_aggregate_results_sanitizes_metric_names():
-    df = IostatStats.dataframe_from_json(iostat_sample())
-    results = IostatStats.aggregate_results(df)
+    df = IoStat.dataframe_from_json(iostat_sample())
+    results = IoStat.aggregate_results(df)
     entries = dict(item.split("=", maxsplit=1) for item in results.rstrip(";").split(";"))
 
     assert float(entries["iostat_nvme0n1_r_s"]) == 2.0

--- a/bm-runner/tests/test_iostat_monitor.py
+++ b/bm-runner/tests/test_iostat_monitor.py
@@ -59,7 +59,7 @@ def disk_sample(device, value):
 
 
 def test_iostat_dataframe_from_json_flattens_samples():
-    df = IoStat._IoStat__transform_json_to_df(iostat_sample())  # type: ignore[unresolved-attribute]
+    df = IoStat._IoStat__transform_json_to_df(iostat_sample())  # ty: ignore[unresolved-attribute]
     assert list(df["time"]) == [0, 0, 1, 1]
     assert list(df["disk_device"]) == ["nvme0n1", "loop0", "nvme0n1", "loop0"]
     assert list(df["r/s"]) == [1.0, 0.0, 3.0, 0.0]
@@ -67,8 +67,8 @@ def test_iostat_dataframe_from_json_flattens_samples():
 
 def test_iostat_aggregate_results_sanitizes_metric_names():
     stat = IoStat("test", [])
-    df = IoStat._IoStat__transform_json_to_df(iostat_sample())  # type: ignore[unresolved-attribute]
-    results = stat._IoStat__get_metric_means(df)  # type: ignore[unresolved-attribute]
+    df = IoStat._IoStat__transform_json_to_df(iostat_sample())  # ty: ignore[unresolved-attribute]
+    results = stat._IoStat__get_metric_means(df)  # ty: ignore[unresolved-attribute]
     entries = dict(item.split("=", maxsplit=1) for item in results.rstrip(";").split(";"))
 
     assert float(entries["iostat_nvme0n1_r_s"]) == 2.0

--- a/config/bm-cgroups.json
+++ b/config/bm-cgroups.json
@@ -111,7 +111,7 @@
         "-C",
         "0"
       ],
-      "iostat":[]
+      "iostat": []
     }
   },
   "containers": {

--- a/config/bm-cgroups.json
+++ b/config/bm-cgroups.json
@@ -110,7 +110,8 @@
       "perf_lock": [
         "-C",
         "0"
-      ]
+      ],
+      "iostat":[]
     }
   },
   "containers": {

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -117,6 +117,7 @@ CPU/Core assignment policy for execution units, i.e. containers and native proce
 Monitors are used to monitor performance. They can be used to analyze the behavior of the benchmarks.  <br/>Supported values:
 - `"mpstat"`:  Runs mpstat and generates related graphs.
 - `"perf"`:  Runs perf and generates flame-graphs.
+- `"iostat"`:  Runs iostat -x and generates block-device graphs.
 - `"redis_benchmark"`:  parses the output of redis_benchmark.
 - `"sar_net"`:  monitors network traffic.
 - `"perf_stat"`:  Runs perf stat.


### PR DESCRIPTION
Add

- `iostat` monitor


Change

- add function `str_to_json` and use it to parse string into JSON
  in both `mpstat` and `iostat`

---
Co-authored-by: Martin Beck <martin.beck2@gmx.de>
Signed-off-by: Martin Beck <martin.beck2@gmx.de>