### PR TITLE
bm-runner/config/container.py: don't go past number of CPUs

### DIFF
--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -165,10 +165,10 @@ class ContainersConfig(dict):
         assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
         # we remove zero from the list
         default_container_list.remove(0)
-        # make sure first element of the list is one
-        if default_container_list[0] != 1:
+        # make sure first element of the list is self.core_count
+        if default_container_list[0] != self.core_count:
             # insert don't overwrite
-            default_container_list.insert(0, 1)
+            default_container_list.insert(0, self.core_count)
         if default_container_list[-1] != max_num_containers:
             default_container_list.append(max_num_containers)
 


### PR DESCRIPTION
The logic which handles the start container is not supposed to go past num_cpus, 
as this causes a crash due to an assert.

You can hit the bug it by removing  container_list key from byte-unixbench.json:

```json
--- a/config/byte-unixbench.json
+++ b/config/byte-unixbench.json
@@ -31,17 +31,6 @@
     }
   },
   "containers": {
-    "container_list": {
-      "values": [
-        [
-          1,
-          2,
-          4,
-          6,
-          8
-        ]
-      ]
-    },
     "core_count": 2
   },
   "applications": [
```