### PR TITLE
[bm-runner] Fix requested CPU count on fallback container list.

### DIFF
--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -112,7 +112,6 @@ class ContainersConfig(dict):
             """
             )
             self.container_list = self.__gen_container_list(max_num_containers)
-            max_cpu_count = max(self.container_list)
             # at the moment we don't respect the pack group policy when
             # determining max #containers, hence when the policy is set to pack by
             # e.g NUMA this can lead to oversubscription. For the time being
@@ -130,9 +129,9 @@ class ContainersConfig(dict):
                 # does not want to interrupt it, and is ok with oversubscription.
         else:
             self.container_list = ListConfig.from_dict(container_list).get_list()
-            # Calculate the maximum number of CPUs needed.
-            # max number of containers * cores per container
-            max_cpu_count = max(self.container_list) * self.core_count
+        # Calculate the maximum number of CPUs needed.
+        # max number of containers * cores per container
+        max_cpu_count = max(self.container_list) * self.core_count
 
         self.cpus = self.topo.select(
             count=max_cpu_count, policy=self.policy, pre_selected=pre_selected_cpus

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -193,6 +193,7 @@ class ContainersConfig(dict):
         last = first + self.core_count  # last index (exclusive)
         assert last <= len(self.cpus)
         cpus_lst = self.cpus[first:last]
+        assert len(cpus_lst) == self.core_count
         cpus_str: str = ",".join(map(str, cpus_lst))
         bm_log(f"Execution Unit#{eu_idx} will be assigned CPUS: {cpus_str}")
         return cpus_str

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -3,36 +3,55 @@
 
 from config.container import ContainersConfig, CoreAssignPolicy
 from utils.logger import bm_log, LogType
+from itertools import product
+import pytest
 
 
-def test_auto_container_list_allocates_enough_cpus(mocker):
+CASES = [
+    (cpu_count, core_count, container_core_count, one_cpu_per_core)
+    for (cpu_count, core_count), container_core_count, one_cpu_per_core in product(
+        [(16, 8), (12, 6), (88, 44), (320, 160), (256, 128)], [1, 2, 3], [False, True]
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "cpu_count,core_count,container_core_count, one_cpu_per_core",
+    CASES,
+)
+def test_get_cpus_with_default_container_list(
+    mocker,
+    cpu_count,
+    core_count,
+    container_core_count,
+    one_cpu_per_core,
+):
     # 16 CPUs available on the machine
     mocker.patch(
         "config.container.Topology.get_cpu_count",
-        return_value=16,
+        return_value=cpu_count,
     )
     mocker.patch(
         "config.container.Topology.get_core_count",
-        return_value=16,
+        return_value=core_count,
     )
-
-    # Topology.select should return exactly as many CPUs as requested
-    mocker.patch(
-        "config.container.Topology.select",
-        side_effect=lambda count, **kwargs: list(range(count)),
-    )
-
-    mocker.patch("config.container.ContainersConfig._ContainersConfig__ensure_img_exists")
 
     cfg = ContainersConfig(
-        core_count=2,
-        core_assignment_policy=CoreAssignPolicy(),
+        core_count=container_core_count,
+        core_assignment_policy=CoreAssignPolicy(one_cpu_per_core=one_cpu_per_core),
     )
 
-    assert max(cfg.container_list) == 8
+    bm_log(
+        f"cores per container:{container_core_count}, #CPU:{cpu_count}, #CORES:{core_count} => {cfg.container_list}",
+        LogType.FATAL,
+    )
 
-    # Should not raise
-    cfg.get_cpus(7)
+    # maximum index we can ask for is: last container count - 1
+    max_container_count = cfg.container_list[-1]
+    max_idx = max_container_count - 1
+    # This function has sanity assertions, that will trigger
+    # if the logic is not sound
+    cfg.get_cpus(max_idx)
 
 
 def test_get_cpus():

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -1,8 +1,50 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-from config.container import ContainersConfig
-from utils.logger import bm_log
+from config.container import ContainersConfig, CoreAssignPolicy
+from utils.logger import bm_log, LogType
+
+
+def test_auto_container_list_allocates_enough_cpus(mocker):
+    # 16 CPUs available on the machine
+    mocker.patch(
+        "config.container.Topology.get_cpu_count",
+        return_value=16,
+    )
+    mocker.patch(
+        "config.container.Topology.get_core_count",
+        return_value=16,
+    )
+
+    # Topology.select should return exactly as many CPUs as requested
+    mocker.patch(
+        "config.container.Topology.select",
+        side_effect=lambda count, **kwargs: list(range(count)),
+    )
+
+    mocker.patch("config.container.ContainersConfig._ContainersConfig__ensure_img_exists")
+
+    cfg = ContainersConfig(
+        core_count=2,
+        core_assignment_policy=CoreAssignPolicy(),
+    )
+
+    assert max(cfg.container_list) == 8
+
+    # Should not raise
+    cfg.get_cpus(7)
+
+
+def test_get_cpus():
+    policy = CoreAssignPolicy(one_cpu_per_core=True)
+    container_cfg = ContainersConfig(core_count=2, core_assignment_policy=policy)
+    bm_log(f"Container list {container_cfg.container_list}", LogType.FATAL)
+
+    for c in container_cfg.container_list:
+        for idx in range(c):
+            bm_log(f"{idx} ==> {container_cfg.cpus}")
+
+            container_cfg.get_cpus(eu_idx=idx)
 
 
 def test_gen_container_list_defaults():

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from config.container import ContainersConfig, CoreAssignPolicy
-from utils.logger import bm_log, LogType
+from utils.logger import bm_log
 from itertools import product
 import pytest
 
@@ -26,7 +26,6 @@ def test_get_cpus_with_default_container_list(
     container_core_count,
     one_cpu_per_core,
 ):
-    # 16 CPUs available on the machine
     mocker.patch(
         "config.container.Topology.get_cpu_count",
         return_value=cpu_count,
@@ -40,12 +39,6 @@ def test_get_cpus_with_default_container_list(
         core_count=container_core_count,
         core_assignment_policy=CoreAssignPolicy(one_cpu_per_core=one_cpu_per_core),
     )
-
-    bm_log(
-        f"cores per container:{container_core_count}, #CPU:{cpu_count}, #CORES:{core_count} => {cfg.container_list}",
-        LogType.FATAL,
-    )
-
     # maximum index we can ask for is: last container count - 1
     max_container_count = cfg.container_list[-1]
     max_idx = max_container_count - 1

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -54,18 +54,6 @@ def test_get_cpus_with_default_container_list(
     cfg.get_cpus(max_idx)
 
 
-def test_get_cpus():
-    policy = CoreAssignPolicy(one_cpu_per_core=True)
-    container_cfg = ContainersConfig(core_count=2, core_assignment_policy=policy)
-    bm_log(f"Container list {container_cfg.container_list}", LogType.FATAL)
-
-    for c in container_cfg.container_list:
-        for idx in range(c):
-            bm_log(f"{idx} ==> {container_cfg.cpus}")
-
-            container_cfg.get_cpus(eu_idx=idx)
-
-
 def test_gen_container_list_defaults():
     container_cfg = ContainersConfig()
     min_steps = container_cfg.MIN_NUM_STEPS

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -45,11 +45,7 @@
     "duration": 1
   },
   "containers": {
-    "core_assignment_policy": {
-      "cpu_order": "desc",
-      "pack_group": "none",
-      "one_cpu_per_core": false
-    }
+    "core_count": 2
   },
   "applications": [
     {

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -45,7 +45,11 @@
     "duration": 1
   },
   "containers": {
-    "core_count": 2
+    "core_assignment_policy": {
+      "cpu_order": "desc",
+      "pack_group": "none",
+      "one_cpu_per_core": false
+    }
   },
   "applications": [
     {


### PR DESCRIPTION
Fix

- `max_cpu_count ` with default container list


Add

- tests to trigger the issue with different configs