### PR TITLE
[bm-runner] Exclude loop devices in `iostat` monitor.

### DIFF
--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -345,3 +345,21 @@ def get_cgroups_version() -> str:
     ).strip()
     version = "v2" if "cgroup2".lower() in cgroup.lower() else "v1"
     return f"{version}"
+
+
+def get_block_devices() -> list[str]:
+    """
+    Return top-level block devices, excluding loop devices.
+    """
+    device_list = []
+    output = shell_out(
+        "lsblk -dn -o NAME -e7",
+        output_is_log=False,
+        print_output=False,
+        print_file_shell_cmd=False,
+    ).strip()
+
+    if output:
+        device_list = [f"/dev/{device}" for device in output.splitlines()]
+
+    return device_list

--- a/bm-runner/monitors/iostat.py
+++ b/bm-runner/monitors/iostat.py
@@ -11,7 +11,7 @@ from monitors.monitor import Monitor
 from utils.logger import LogType, bm_log
 from utils.process import BackgroundProcess
 from bm_visualize import plot_chart, PlotConfig, PlotType
-from bm_utils import str_to_json
+from bm_utils import str_to_json, get_block_devices
 import os
 
 
@@ -33,7 +33,8 @@ class IoStat(Monitor):
 
     def __init__(self, output_dir: str, args: list[str] = []):
         super().__init__(dir=output_dir, args=args)
-        cmds = ["iostat", "-x", "-o", "JSON", "-y"]
+        cmds = ["iostat", "-dx", "-o", "JSON", "-y"]
+        cmds.extend(get_block_devices())
         cmds.extend(args)
         cmds.append(str(self.INTERVAL))
         self.name = "iostat"


### PR DESCRIPTION
Change

- let `iostat` monitor non-loop devices only.