### PR TITLE
[AI] CSB remote skill

### DIFF
--- a/.agents/skills/csb-remote/SKILL.md
+++ b/.agents/skills/csb-remote/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: csb-remote
+description: "Use when CSB work is executed on one or more remote benchmark machines over SSH while the current host acts as the AI/controller host: preparing remote CSB checkouts and dependencies, installing benchmark/monitor tooling, setting permissions, syncing host skills/templates/configs, running CSB usage/analysis/refine/dev commands remotely, handling reconnects and cleanup, coordinating multiple remote machines, and copying results/reports/configs/monitor artifacts back into remote-specific result directories on the host."
+---
+
+# CSB Remote
+
+Use this skill whenever a CSB benchmark, refinement, analysis rerun, monitor capture, source checkout, build, or validation is performed on an SSH-accessible remote machine instead of the controller host running Codex.
+
+## Roles
+
+- **Controller host**: the machine running the AI agent. It owns the Codex skills, local instructions, final copied reports, and cross-remote organization.
+- **Remote benchmark host**: the machine that executes CSB commands, benchmarks, monitors, package installs, source checkouts, kernel-source correlation, builds, and cleanup.
+- Treat the remote as the source of truth for benchmark outputs, system/kernel facts, monitor availability, and tested source trees. The controller can generate or edit skill-guided scripts/configs, but every runtime check and benchmark command must be executed remotely.
+
+## Skill Composition
+
+Use this skill with the relevant CSB skill:
+
+- `csb`: choose/adapt configs and run campaigns remotely.
+- `csb-analysis`: analyze remote result artifacts and perform source/perf inspection against the remote's tested kernel/source tree.
+- `csb-refine`: perform every sweep, cleanup, monitor adaptation, diagnostic run, report generation, and patch/object-build test remotely.
+- `csb-dev`: reproduce framework bugs, run tests, and validate monitor/runner changes remotely when the behavior depends on remote-only permissions, hardware, kernel, containers, perf, bpftrace, or topology.
+
+When instructions in another CSB skill say "host", "machine", "testing machine", "local command", or "prepare the environment", interpret that as the remote benchmark host for remote work. Keep only final aggregation, copied artifacts, and skill files on the controller unless explicitly asked to edit the remote checkout.
+
+## Remote Inventory
+
+For each remote, record a short inventory before running CSB:
+
+```bash
+ssh <remote> 'hostname; pwd; uname -a; cat /etc/os-release 2>/dev/null || true; nproc; lscpu | sed -n "1,80p"'
+ssh <remote> 'command -v git python3 sudo perf bpftrace docker runc youki mpstat iostat || true'
+ssh <remote> 'test -d /path/to/csb && git -C /path/to/csb status --short || true'
+```
+
+Keep this mapping in notes or reports:
+
+- remote name and SSH target;
+- remote CSB checkout path;
+- remote result group/root;
+- remote kernel/source tree path, usually `deps/linux`;
+- runtime/container tools and monitor permissions;
+- any node-specific cleanup/runtime quirks.
+
+Multiple remotes may be used simultaneously. Prefix tmux sessions, result groups, temp configs, and copied directories with the remote name so artifacts do not collide.
+
+## Remote Setup
+
+The remote must have a complete CSB setup with all dependencies needed by the selected CSB skills. Execute the checks and setup on the remote:
+
+```bash
+ssh <remote> 'cd /path/to/csb && scripts/prepare.sh'
+ssh <remote> 'cd /path/to/csb && cmake -S. -Bbuild && cmake --build build -j"$(nproc)"'
+ssh <remote> 'cd /path/to/csb && python3 -m json.tool config/<file>.json >/dev/null'
+```
+
+Install missing software on the remote, not the controller, when needed for the requested benchmark or monitors. Typical packages/tools include Python build dependencies, CMake, Docker or the selected OCI runtime, sysstat (`mpstat`/`iostat`), `perf`, `bpftrace`, benchmark-specific `*-dev` packages, and kernel build/source dependencies.
+
+For perf, tracefs, bpftrace, Arm SPE, containers, cgroups, NICs, and kernel-source setup, run the permission and availability commands from `csb`, `csb-analysis`, and `csb-refine` on the remote. Do not infer remote capability from the controller.
+
+## Source Trees
+
+Kernel source used for source correlation and object-build tests belongs on the remote unless the user explicitly asks for host-only analysis. Use one remote `deps/linux` tree:
+
+- add or update a Torvalds remote for upstream comparison;
+- add or update the tested distro/vendor/kernel remote;
+- check out the branch/tag/commit closest to the running remote kernel;
+- record remotes, checked-out commit, dirty state, and comparison ref in reports.
+
+If host skills provide bpftrace templates, helper scripts, or report generators that are not present remotely, copy those files to a temporary remote path or into the remote CSB checkout before running. Treat controller copies as templates; executed scripts and generated programs should live in the remote run artifacts and be copied back afterward.
+
+## Running Remotely
+
+Run CSB through SSH from the remote CSB checkout:
+
+```bash
+ssh <remote> 'cd /path/to/csb && CSB_RESULTS_GROUP=<remote>_<group> scripts/run-single.sh config/<file>.json'
+```
+
+For long runs, use `tmux` or `systemd-run` on the remote and reconnect until completion:
+
+```bash
+ssh <remote> 'cd /path/to/csb && tmux new-session -d -s csb_<remote>_<name> "CSB_RESULTS_GROUP=<group> scripts/run-single.sh config/<file>.json 2>&1 | tee results/<group>.log"'
+ssh <remote> 'tmux capture-pane -pt csb_<remote>_<name> -S -200'
+```
+
+If the SSH connection drops, reconnect and inspect the remote session/processes. Do not restart a sweep until you know whether the prior sweep is still running, completed, or failed and cleanup is needed.
+
+## Cleanup Between Sweeps
+
+Before every new remote CSB sweep, perform the cleanup required by `csb-refine` on that remote. Clean only artifacts belonging to the prior CSB sweep:
+
+- stale benchmark/application processes;
+- stale Docker/runc/youki/runtime state with the benchmark prefix;
+- stale monitor processes such as `perf`, `perf lock`, `bpftrace`, `mpstat`, `iostat`;
+- CSB start barriers such as `build/bench/start`;
+- temporary monitor files, oversized partial perf data, and scratch dirs not meant to be kept.
+
+Re-check after cleanup with process/runtime-specific commands. Record the cleanup summary in the remote run report.
+
+## Copy-Back Layout
+
+At the end of each remote task, copy all final results, reports, configs, generated bpftrace programs, helper scripts, and patch artifacts back to the controller under a remote-specific directory. Prefer this layout:
+
+```text
+results/remote/<remote>/<task-or-group>/
+  results/          # copied remote results/<group> or selected run dirs
+  reports/          # summary/detailed/cross-run reports
+  configs/          # configs used for the remote runs
+  monitors/         # generated bpftrace programs, perf scripts, helper probes
+  patches/          # RFC patches and patch support docs, if any
+  logs/             # driver logs, tmux captures, install/setup notes
+  inventory/        # uname, lscpu, os-release, tool versions, git refs
+```
+
+Use `rsync -a --info=progress2` or `scp -r` from the controller. For large `perf.data`, flamegraphs, or traces, copy only the artifacts needed for analysis unless the user asks for full raw data. Preserve remote filenames and run basenames so CSB result sibling relationships remain recognizable.
+
+For multiple remotes, keep one subtree per remote and add a top-level cross-remote index/report only after all per-remote artifacts are copied.
+
+## Reporting
+
+Remote reports must state:
+
+- which commands ran remotely and which ran on the controller;
+- remote hostname, kernel, CPU/topology, cgroup mode, runtime, monitor availability, and source tree commits;
+- cleanup performed before each sweep;
+- copied-back artifact paths on the controller;
+- any remote-only installs, permission changes, sudo limitations, reconnects, or failed monitor probes;
+- whether raw data stayed remote due to size, and how to retrieve it if needed.
+
+When the user asks for "all reports/results/configs copied back", verify the controller copy has the expected Markdown/HTML/CSV/JSON/result directories before finishing.

--- a/.agents/skills/csb-remote/SKILL.md
+++ b/.agents/skills/csb-remote/SKILL.md
@@ -1,32 +1,32 @@
 ---
 name: csb-remote
-description: "Use when CSB work is executed on one or more remote benchmark machines over SSH while the current host acts as the AI/controller host: preparing remote CSB checkouts and dependencies, installing benchmark/monitor tooling, setting permissions, syncing host skills/templates/configs, running CSB usage/analysis/refine/dev commands remotely, handling reconnects and cleanup, coordinating multiple remote machines, and copying results/reports/configs/monitor artifacts back into remote-specific result directories on the host."
+description: "Use when CSB work runs on one or more SSH benchmark hosts while the current host acts as controller: remote setup, benchmark/refine/analysis/dev commands, monitor permissions, reconnects, multi-host coordination, and copying results/reports/configs/artifacts back."
 ---
 
 # CSB Remote
 
-Use this skill whenever a CSB benchmark, refinement, analysis rerun, monitor capture, source checkout, build, or validation is performed on an SSH-accessible remote machine instead of the controller host running Codex.
+This is a remote-execution overlay for CSB work. Apply the relevant CSB skill or docs normally, but run machine-dependent steps on the SSH benchmark host and copy final artifacts back to the controller.
 
-## Roles
+## Compose With
 
-- **Controller host**: the machine running the AI agent. It owns the Codex skills, local instructions, final copied reports, and cross-remote organization.
-- **Remote benchmark host**: the machine that executes CSB commands, benchmarks, monitors, package installs, source checkouts, kernel-source correlation, builds, and cleanup.
-- Treat the remote as the source of truth for benchmark outputs, system/kernel facts, monitor availability, and tested source trees. The controller can generate or edit skill-guided scripts/configs, but every runtime check and benchmark command must be executed remotely.
+- `csb`: benchmark setup, configs, monitors, and campaign execution.
+- `csb-analysis`: result analysis, source correlation, perf/flamegraph/lock evidence, patch artifacts.
+- `csb-refine`: iterative reruns, cleanup, monitor adaptation, conclusions, object-build testing.
+- Project docs for stable CSB facts: `doc/bm-runner.md`, `doc/bm-config.md`, `doc/development.md`, plus app notes under `doc/bm-external/` and `doc/org-apps/`.
 
-## Skill Composition
+When those sources say "host", "machine", "local command", "testing machine", or "prepare the environment", read it as the remote benchmark host for remote work. Keep controller-only work limited to orchestration, skill/template editing, copied artifacts, and cross-remote summaries unless the user asks otherwise.
 
-Use this skill with the relevant CSB skill:
+## Remote Invariants
 
-- `csb`: choose/adapt configs and run campaigns remotely.
-- `csb-analysis`: analyze remote result artifacts and perform source/perf inspection against the remote's tested kernel/source tree.
-- `csb-refine`: perform every sweep, cleanup, monitor adaptation, diagnostic run, report generation, and patch/object-build test remotely.
-- `csb-dev`: reproduce framework bugs, run tests, and validate monitor/runner changes remotely when the behavior depends on remote-only permissions, hardware, kernel, containers, perf, bpftrace, or topology.
+- Treat the remote as source of truth for benchmark output, kernel facts, topology, cgroups, runtimes, monitor availability, permissions, and source trees.
+- Run all runtime checks, package installs, benchmark commands, monitor captures, cleanup, artifact-dependent analysis, and kernel builds on the remote.
+- Do not infer remote capability from the controller. Verify Docker/runc/youki, perf, tracefs, bpftrace, sysstat, NICs, cgroups, and kernel source on the remote.
+- For multiple remotes, prefix tmux sessions, result groups, temp configs, and copied directories with the remote name.
+- If SSH drops, reconnect and inspect remote sessions/processes before restarting or cleaning up.
 
-When instructions in another CSB skill say "host", "machine", "testing machine", "local command", or "prepare the environment", interpret that as the remote benchmark host for remote work. Keep only final aggregation, copied artifacts, and skill files on the controller unless explicitly asked to edit the remote checkout.
+## Minimal Inventory
 
-## Remote Inventory
-
-For each remote, record a short inventory before running CSB:
+Record this before running CSB and include it in reports:
 
 ```bash
 ssh <remote> 'hostname; pwd; uname -a; cat /etc/os-release 2>/dev/null || true; nproc; lscpu | sed -n "1,80p"'
@@ -34,74 +34,28 @@ ssh <remote> 'command -v git python3 sudo perf bpftrace docker runc youki mpstat
 ssh <remote> 'test -d /path/to/csb && git -C /path/to/csb status --short || true'
 ```
 
-Keep this mapping in notes or reports:
+Also track: SSH target, remote CSB checkout path, result group/root, kernel/source path, runtime and monitor permissions, and any node-specific cleanup quirks.
 
-- remote name and SSH target;
-- remote CSB checkout path;
-- remote result group/root;
-- remote kernel/source tree path, usually `deps/linux`;
-- runtime/container tools and monitor permissions;
-- any node-specific cleanup/runtime quirks.
+## Execution Pattern
 
-Multiple remotes may be used simultaneously. Prefix tmux sessions, result groups, temp configs, and copied directories with the remote name so artifacts do not collide.
-
-## Remote Setup
-
-The remote must have a complete CSB setup with all dependencies needed by the selected CSB skills. Execute the checks and setup on the remote:
-
-```bash
-ssh <remote> 'cd /path/to/csb && scripts/prepare.sh'
-ssh <remote> 'cd /path/to/csb && cmake -S. -Bbuild && cmake --build build -j"$(nproc)"'
-ssh <remote> 'cd /path/to/csb && python3 -m json.tool config/<file>.json >/dev/null'
-```
-
-Install missing software on the remote, not the controller, when needed for the requested benchmark or monitors. Typical packages/tools include Python build dependencies, CMake, Docker or the selected OCI runtime, sysstat (`mpstat`/`iostat`), `perf`, `bpftrace`, benchmark-specific `*-dev` packages, and kernel build/source dependencies.
-
-For perf, tracefs, bpftrace, Arm SPE, containers, cgroups, NICs, and kernel-source setup, run the permission and availability commands from `csb`, `csb-analysis`, and `csb-refine` on the remote. Do not infer remote capability from the controller.
-
-## Source Trees
-
-Kernel source used for source correlation and object-build tests belongs on the remote unless the user explicitly asks for host-only analysis. Use one remote `deps/linux` tree:
-
-- add or update a Torvalds remote for upstream comparison;
-- add or update the tested distro/vendor/kernel remote;
-- check out the branch/tag/commit closest to the running remote kernel;
-- record remotes, checked-out commit, dirty state, and comparison ref in reports.
-
-If host skills provide bpftrace templates, helper scripts, or report generators that are not present remotely, copy those files to a temporary remote path or into the remote CSB checkout before running. Treat controller copies as templates; executed scripts and generated programs should live in the remote run artifacts and be copied back afterward.
-
-## Running Remotely
-
-Run CSB through SSH from the remote CSB checkout:
+Use SSH from the controller and execute from the remote CSB checkout:
 
 ```bash
 ssh <remote> 'cd /path/to/csb && CSB_RESULTS_GROUP=<remote>_<group> scripts/run-single.sh config/<file>.json'
 ```
 
-For long runs, use `tmux` or `systemd-run` on the remote and reconnect until completion:
+For long runs, prefer a remote `tmux` or `systemd-run` session:
 
 ```bash
 ssh <remote> 'cd /path/to/csb && tmux new-session -d -s csb_<remote>_<name> "CSB_RESULTS_GROUP=<group> scripts/run-single.sh config/<file>.json 2>&1 | tee results/<group>.log"'
 ssh <remote> 'tmux capture-pane -pt csb_<remote>_<name> -S -200'
 ```
 
-If the SSH connection drops, reconnect and inspect the remote session/processes. Do not restart a sweep until you know whether the prior sweep is still running, completed, or failed and cleanup is needed.
-
-## Cleanup Between Sweeps
-
-Before every new remote CSB sweep, perform the cleanup required by `csb-refine` on that remote. Clean only artifacts belonging to the prior CSB sweep:
-
-- stale benchmark/application processes;
-- stale Docker/runc/youki/runtime state with the benchmark prefix;
-- stale monitor processes such as `perf`, `perf lock`, `bpftrace`, `mpstat`, `iostat`;
-- CSB start barriers such as `build/bench/start`;
-- temporary monitor files, oversized partial perf data, and scratch dirs not meant to be kept.
-
-Re-check after cleanup with process/runtime-specific commands. Record the cleanup summary in the remote run report.
+Before reruns, use the cleanup guidance from `csb-refine` on the remote only. Clean stale processes, runtime state, monitors, start barriers, and scratch artifacts that belong to the prior CSB sweep; re-check and record the cleanup summary.
 
 ## Copy-Back Layout
 
-At the end of each remote task, copy all final results, reports, configs, generated bpftrace programs, helper scripts, and patch artifacts back to the controller under a remote-specific directory. Prefer this layout:
+At the end of each task, copy final results, reports, configs, generated probes/scripts, logs, and patch artifacts to:
 
 ```text
 results/remote/<remote>/<task-or-group>/
@@ -114,19 +68,10 @@ results/remote/<remote>/<task-or-group>/
   inventory/        # uname, lscpu, os-release, tool versions, git refs
 ```
 
-Use `rsync -a --info=progress2` or `scp -r` from the controller. For large `perf.data`, flamegraphs, or traces, copy only the artifacts needed for analysis unless the user asks for full raw data. Preserve remote filenames and run basenames so CSB result sibling relationships remain recognizable.
-
-For multiple remotes, keep one subtree per remote and add a top-level cross-remote index/report only after all per-remote artifacts are copied.
+Use `rsync -a --info=progress2` or `scp -r`. For large `perf.data`, flamegraphs, or traces, copy only what is needed unless the user asks for full raw data. Preserve remote filenames/run basenames.
 
 ## Reporting
 
-Remote reports must state:
-
-- which commands ran remotely and which ran on the controller;
-- remote hostname, kernel, CPU/topology, cgroup mode, runtime, monitor availability, and source tree commits;
-- cleanup performed before each sweep;
-- copied-back artifact paths on the controller;
-- any remote-only installs, permission changes, sudo limitations, reconnects, or failed monitor probes;
-- whether raw data stayed remote due to size, and how to retrieve it if needed.
+Reports should state which work ran remotely vs on the controller; hostname/kernel/CPU/cgroups/runtime/monitors/source commits; cleanup performed; copied-back paths; remote installs or permission changes; reconnects or failed probes; and any raw data intentionally left remote.
 
 When the user asks for "all reports/results/configs copied back", verify the controller copy has the expected Markdown/HTML/CSV/JSON/result directories before finishing.

--- a/.agents/skills/csb-remote/SKILL.md
+++ b/.agents/skills/csb-remote/SKILL.md
@@ -56,7 +56,7 @@ Use SSH from the controller and execute from the remote CSB checkout:
 ssh <remote> 'cd /path/to/csb && CSB_RESULTS_GROUP=<remote>_<group> scripts/run-single.sh config/<file>.json'
 ```
 
-For long runs, prefer a remote `tmux` or `systemd-run` session:
+Always use a remote `tmux` or `systemd-run` session:
 
 ```bash
 ssh <remote> 'cd /path/to/csb && tmux new-session -d -s csb-remote_<remote>_<name> "CSB_RESULTS_GROUP=<group> scripts/run-single.sh config/<file>.json 2>&1 | tee results/<group>.log"'

--- a/.agents/skills/csb-remote/SKILL.md
+++ b/.agents/skills/csb-remote/SKILL.md
@@ -1,27 +1,39 @@
 ---
 name: csb-remote
-description: "Use when CSB work runs on one or more SSH benchmark hosts while the current host acts as controller: remote setup, benchmark/refine/analysis/dev commands, monitor permissions, reconnects, multi-host coordination, and copying results/reports/configs/artifacts back."
+description: "Use when CSB work runs on one or more SSH benchmark hosts while the current host acts as controller: remote setup, benchmark/refine/analysis commands, monitor permissions, reconnects, multi-host coordination, and copying results/reports/configs/artifacts back."
 ---
 
 # CSB Remote
 
-This is a remote-execution overlay for CSB work. Apply the relevant CSB skill or docs normally, but run machine-dependent steps on the SSH benchmark host and copy final artifacts back to the controller.
+This is a remote-execution overlay for CSB work. Apply the relevant CSB skill or docs normally, but run benchmark-machine-dependent steps on the SSH benchmark host and keep kernel-source work on the controller.
 
 ## Compose With
 
-- `csb`: benchmark setup, configs, monitors, and campaign execution.
-- `csb-analysis`: result analysis, source correlation, perf/flamegraph/lock evidence, patch artifacts.
-- `csb-refine`: iterative reruns, cleanup, monitor adaptation, conclusions, object-build testing.
+- `csb`: benchmark setup, config selection, monitors, and campaign execution.
+- `csb-analysis`: result analysis, perf/flamegraph/lock evidence, controller-side source correlation, patch artifacts.
+- `csb-refine`: iterative reruns, cleanup, monitor adaptation, conclusions, controller-side object-build testing.
 - Project docs for stable CSB facts: `doc/bm-runner.md`, `doc/bm-config.md`, `doc/development.md`, plus app notes under `doc/bm-external/` and `doc/org-apps/`.
 
-When those sources say "host", "machine", "local command", "testing machine", or "prepare the environment", read it as the remote benchmark host for remote work. Keep controller-only work limited to orchestration, skill/template editing, copied artifacts, and cross-remote summaries unless the user asks otherwise.
+When those sources say "host", "machine", "testing machine", or "prepare the environment", read it as the remote benchmark host only for benchmark runtime, monitor, permission, package, cgroup, topology, and cleanup work. Keep all kernel source trees, kernel git remotes, source correlation, patch-history searches, patch artifacts, and object-build tests on the controller.
+
+## SSH Access
+
+Verify SSH with a non-destructive command before setup or benchmarks:
+
+```bash
+ssh <remote> 'hostname'
+```
+
+If access fails, help diagnose the SSH target, username, key, host key, jump host, or `~/.ssh/config` entry. Do not start setup, package installation, or CSB runs until the remote host is reachable.
 
 ## Remote Invariants
 
-- Treat the remote as source of truth for benchmark output, kernel facts, topology, cgroups, runtimes, monitor availability, permissions, and source trees.
-- Run all runtime checks, package installs, benchmark commands, monitor captures, cleanup, artifact-dependent analysis, and kernel builds on the remote.
-- Do not infer remote capability from the controller. Verify Docker/runc/youki, perf, tracefs, bpftrace, sysstat, NICs, cgroups, and kernel source on the remote.
-- For multiple remotes, prefix tmux sessions, result groups, temp configs, and copied directories with the remote name.
+- Treat the remote as source of truth for benchmark output, running-kernel facts, topology, cgroups, runtimes, monitor availability, and permissions.
+- Run runtime checks, package installs, benchmark commands, monitor captures, and cleanup on the remote.
+- Keep kernel source under the controller checkout. Any added kernel git remote, branch, tag, commit, dirty-state note, or comparison ref used by `csb-analysis` or `csb-refine` must match the remote host's running kernel, not the controller's kernel.
+- Do not infer remote capability from the controller. Verify Docker/runc/youki, perf, tracefs, bpftrace, sysstat, NICs, cgroups, and running-kernel identity on the remote.
+- For multiple remote hosts, prefix tmux sessions, result groups, temp configs, and copied directories with `csb-remote_<remote>_`.
+- Do not kill, rename, or reuse unrelated user tmux sessions.
 - If SSH drops, reconnect and inspect remote sessions/processes before restarting or cleaning up.
 
 ## Minimal Inventory
@@ -34,7 +46,7 @@ ssh <remote> 'command -v git python3 sudo perf bpftrace docker runc youki mpstat
 ssh <remote> 'test -d /path/to/csb && git -C /path/to/csb status --short || true'
 ```
 
-Also track: SSH target, remote CSB checkout path, result group/root, kernel/source path, runtime and monitor permissions, and any node-specific cleanup quirks.
+Also track: SSH target, remote CSB checkout path, result group/root, remote running-kernel identity, controller kernel-source path/ref used for that host, runtime and monitor permissions, and any node-specific cleanup quirks.
 
 ## Execution Pattern
 
@@ -47,22 +59,22 @@ ssh <remote> 'cd /path/to/csb && CSB_RESULTS_GROUP=<remote>_<group> scripts/run-
 For long runs, prefer a remote `tmux` or `systemd-run` session:
 
 ```bash
-ssh <remote> 'cd /path/to/csb && tmux new-session -d -s csb_<remote>_<name> "CSB_RESULTS_GROUP=<group> scripts/run-single.sh config/<file>.json 2>&1 | tee results/<group>.log"'
-ssh <remote> 'tmux capture-pane -pt csb_<remote>_<name> -S -200'
+ssh <remote> 'cd /path/to/csb && tmux new-session -d -s csb-remote_<remote>_<name> "CSB_RESULTS_GROUP=<group> scripts/run-single.sh config/<file>.json 2>&1 | tee results/<group>.log"'
+ssh <remote> 'tmux capture-pane -pt csb-remote_<remote>_<name> -S -200'
 ```
 
-Before reruns, use the cleanup guidance from `csb-refine` on the remote only. Clean stale processes, runtime state, monitors, start barriers, and scratch artifacts that belong to the prior CSB sweep; re-check and record the cleanup summary.
+Before reruns, use the cleanup guidance from the active CSB skill on the remote only. Clean only artifacts that belong to the prior CSB sweep, then re-check and record the cleanup summary.
 
 ## Copy-Back Layout
 
-At the end of each task, copy final results, reports, configs, generated probes/scripts, logs, and patch artifacts to:
+At the end of each task, copy final CSB result directories and task-produced reports/configs/logs to the controller. Include monitor or patch artifacts only when they were generated remotely and are needed for analysis or review:
 
 ```text
 results/remote/<remote>/<task-or-group>/
   results/          # copied remote results/<group> or selected run dirs
   reports/          # summary/detailed/cross-run reports
   configs/          # configs used for the remote runs
-  monitors/         # generated bpftrace programs, perf scripts, helper probes
+  monitors/         # generated probes or profiler artifacts needed for analysis
   patches/          # RFC patches and patch support docs, if any
   logs/             # driver logs, tmux captures, install/setup notes
   inventory/        # uname, lscpu, os-release, tool versions, git refs
@@ -72,6 +84,6 @@ Use `rsync -a --info=progress2` or `scp -r`. For large `perf.data`, flamegraphs,
 
 ## Reporting
 
-Reports should state which work ran remotely vs on the controller; hostname/kernel/CPU/cgroups/runtime/monitors/source commits; cleanup performed; copied-back paths; remote installs or permission changes; reconnects or failed probes; and any raw data intentionally left remote.
+Reports should state which work ran remotely vs on the controller; remote hostname/kernel/CPU/cgroups/runtime/monitors; controller kernel-source path/ref chosen for that remote host; cleanup performed; copied-back paths; remote installs or permission changes; reconnects or failed probes; and any raw data intentionally left remote.
 
 When the user asks for "all reports/results/configs copied back", verify the controller copy has the expected Markdown/HTML/CSV/JSON/result directories before finishing.

--- a/.agents/skills/csb-remote/agents/openai.yaml
+++ b/.agents/skills/csb-remote/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "CSB Remote"
   short_description: "Run CSB workflows on SSH benchmark hosts"
-  default_prompt: "Use $csb-remote when CSB benchmarks, analysis, refinement, monitor collection, package setup, kernel source checkout, builds, or validation should run on one or more SSH remote machines while this host acts as the controller, then copy results and reports back into remote-specific directories."
+  default_prompt: "Use $csb-remote when CSB benchmarks, analysis, refinement, monitor collection, setup, source checkout, builds, or validation should run on SSH hosts while this machine acts as controller. Run host-dependent steps remotely and copy results, reports, configs, logs, and artifacts back into remote-specific directories."
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/csb-remote/agents/openai.yaml
+++ b/.agents/skills/csb-remote/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "CSB Remote"
+  short_description: "Run CSB workflows on SSH benchmark hosts"
+  default_prompt: "Use $csb-remote when CSB benchmarks, analysis, refinement, monitor collection, package setup, kernel source checkout, builds, or validation should run on one or more SSH remote machines while this host acts as the controller, then copy results and reports back into remote-specific directories."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/csb-remote/agents/openai.yaml
+++ b/.agents/skills/csb-remote/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "CSB Remote"
   short_description: "Run CSB workflows on SSH benchmark hosts"
-  default_prompt: "Use $csb-remote when CSB benchmarks, analysis, refinement, monitor collection, setup, source checkout, builds, or validation should run on SSH hosts while this machine acts as controller. Run host-dependent steps remotely and copy results, reports, configs, logs, and artifacts back into remote-specific directories."
+  default_prompt: "Use $csb-remote when CSB benchmarks, analysis, refinement, monitor collection, setup, source checkout, or object-build tests should run on SSH benchmark hosts while this machine acts as controller. Run host-dependent steps remotely and copy results, reports, configs, logs, and needed artifacts back into remote-specific directories."
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
Adds:
 - initial version of remote skill for ai agent usage 
 - allows to run csb workflows from a controller and have the actual csb benchmark runs on multiple different remote ssh machines