### PR TITLE
[bm-runner] Fix errors related to `comm` parsing and `youki` in `bpftrace` monitor.

### DIFF
--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -24,7 +24,7 @@ class BpfTrace(Monitor):
     COUNT = "count"
     BUCKET = "bucket"
 
-    HEADER_REGEX = f"@(?P<{NAME}>\w+)\[(?P<{PID}>\d+),\s*(?P<{COMM}>[^\]]+)\]:"
+    HEADER_REGEX = rf"@(?P<{NAME}>\w+)\[(?P<{PID}>\d+),\s*(?P<{COMM}>.+)\]:"
 
     def __init__(self, output_dir: str, args: list[str] = []):
         super().__init__(dir=output_dir, args=args)
@@ -266,20 +266,24 @@ class BpfTrace(Monitor):
                 title=trace_point,
             )
             PlotChart.plot(plot=cfg, df=plot_df, out_fig_name=fname)
+            if len(df[self.COMM].unique()) > 1:
+                bm_log(
+                    "Multiple COMM values detected. All will be treated as same process!",
+                    LogType.WARNING,
+                )
             # In order to create data that summarizes the full run
             # we remove PID col, and sum up data of all processes
-            sum_df = df.drop(columns=self.PID).groupby([self.NAME, self.COMM], as_index=False).sum()
+            sum_df = (
+                df.drop(columns=[self.PID, self.COMM]).groupby([self.NAME], as_index=False).sum()
+            )
             # since we expect the data to be related to one COMM and trace point, we expect to have
             # only one row.
-            if len(sum_df) > 1:
-                bm_log("multi comm/trace point is not supported", LogType.ERROR)
-            else:
-                # we compress the data of all buckets into on string
-                for _, row in sum_df.iterrows():
-                    hist_data = ",".join(
-                        f"{col}{self.BUCKET_EQUAL_CHAR}{int(val)}"
-                        for col, val in row[bucket_cols].items()
-                    )
+            # we compress the data of all buckets into on string
+            for _, row in sum_df.iterrows():
+                hist_data = ",".join(
+                    f"{col}{self.BUCKET_EQUAL_CHAR}{int(val)}"
+                    for col, val in row[bucket_cols].items()
+                )
         # always output to maintain same number of cols in CSV
         output = f"{prefix}='{hist_data}';"
         return output

--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -279,7 +279,7 @@ class BpfTrace(Monitor):
             # since we expect the data to be related to one trace point, we expect to have
             # only one row.
             if len(sum_df) > 1:
-                bm_log("multi trace points is not supported", LogType.ERROR)
+                bm_log(f"{fname}: multi trace points is not supported", LogType.ERROR)
             else:
                 # we compress the data of all buckets into on string
                 for _, row in sum_df.iterrows():

--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -268,7 +268,7 @@ class BpfTrace(Monitor):
             PlotChart.plot(plot=cfg, df=plot_df, out_fig_name=fname)
             if len(df[self.COMM].unique()) > 1:
                 bm_log(
-                    "Multiple COMM values detected. All will be treated as same process!",
+                    f"{fname}: Multiple COMM values detected. All will be treated as same process!",
                     LogType.WARNING,
                 )
             # In order to create data that summarizes the full run

--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -276,14 +276,17 @@ class BpfTrace(Monitor):
             sum_df = (
                 df.drop(columns=[self.PID, self.COMM]).groupby([self.NAME], as_index=False).sum()
             )
-            # since we expect the data to be related to one COMM and trace point, we expect to have
+            # since we expect the data to be related to one trace point, we expect to have
             # only one row.
-            # we compress the data of all buckets into on string
-            for _, row in sum_df.iterrows():
-                hist_data = ",".join(
-                    f"{col}{self.BUCKET_EQUAL_CHAR}{int(val)}"
-                    for col, val in row[bucket_cols].items()
-                )
+            if len(sum_df) > 1:
+                bm_log("multi trace points is not supported", LogType.ERROR)
+            else:
+                # we compress the data of all buckets into on string
+                for _, row in sum_df.iterrows():
+                    hist_data = ",".join(
+                        f"{col}{self.BUCKET_EQUAL_CHAR}{int(val)}"
+                        for col, val in row[bucket_cols].items()
+                    )
         # always output to maintain same number of cols in CSV
         output = f"{prefix}='{hist_data}';"
         return output

--- a/doc/bm-external/cgroups.md
+++ b/doc/bm-external/cgroups.md
@@ -60,5 +60,5 @@ CSB_BPFTRACE_FILTER='/ comm == "runc" /' ./scripts/run-single.sh config/bm-exter
 For running the benchmark with the [youki](https://github.com/youki-dev/youki) runtime, please make `youki` executable available in the `$PATH`, and then run:
 
 ```bash
-CSB_BPFTRACE_FILTER='/ strcontains(comm, "youki") /' ./scripts/run-single.sh config/bm-external/bm-cgroups-youki.json
+CSB_BPFTRACE_FILTER='/ comm=="youki" || comm=="youki:[1:INTER]" || comm=="youki:[2:INIT]" /'  ./scripts/run-single.sh config/bm-external/bm-cgroups-youki.json
 ```

--- a/doc/bm-external/cgroups.md
+++ b/doc/bm-external/cgroups.md
@@ -60,5 +60,5 @@ CSB_BPFTRACE_FILTER='/ comm == "runc" /' ./scripts/run-single.sh config/bm-exter
 For running the benchmark with the [youki](https://github.com/youki-dev/youki) runtime, please make `youki` executable available in the `$PATH`, and then run:
 
 ```bash
-CSB_BPFTRACE_FILTER='/ comm == "youki" /' ./scripts/run-single.sh config/bm-external/bm-cgroups-youki.json
+CSB_BPFTRACE_FILTER='/ strcontains(comm, "youki") /' ./scripts/run-single.sh config/bm-external/bm-cgroups-youki.json
 ```


### PR DESCRIPTION
Fix

- change the header regex in bpftrace monitor to a greedy one.
  some COMM values may contain these chars `:`, `]`
- if multiple `comm` is present in the dataframe
  warn the user that they will be considered the same 
  in the final compressed CSV data