### PR TITLE
[bm-runner] Await the attachment of the probes in `bpftrace` monitor.

### DIFF
--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -133,6 +133,14 @@ class BpfTrace(Monitor):
     def start(self):
         for trace in self.traces.values():
             trace.start()
+        self.__await_probes_attached()
+
+    def __await_probes_attached(self):
+        for prefix, trace in self.traces.items():
+            if trace.await_token("Attaching"):
+                bm_log(f"{self.name}:{prefix} probe attached successfully.")
+            else:
+                bm_log(f"{self.name}:{prefix} cannot confirm probe is attached!", LogType.ERROR)
 
     def stop(self):
         for prefix, trace in self.traces.items():

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -8,6 +8,7 @@ from utils.logger import bm_log, LogType
 from typing import Optional
 from bm_utils import ensure_exists
 from bm_utils import stop_process
+import time
 
 
 class BackgroundProcess:
@@ -181,3 +182,29 @@ class BackgroundProcess:
         Returns the full path of the error file name of the process.
         """
         return self.efile_name
+
+    def await_token(self, token: str, timeout=10) -> bool:
+        """
+        Wait until the first line of the output file contains `token` or the
+        timeout expires.
+
+        Returns
+        -------
+        bool
+            True if the token is detected in the first line of the output file.
+
+            False if the timeout expires, the process exits before the token is
+            detected, or an error prevents reading the output file.
+        """
+        deadline = time.monotonic() + timeout
+        if self.process:
+            # as long as the process is running
+            while self.process.poll() is None and time.monotonic() < deadline:
+                try:
+                    with open(self.output_file_name, "r") as f:
+                        line = f.readline()
+                        if token in line:
+                            return True
+                except Exception:
+                    pass
+        return False


### PR DESCRIPTION
Change

- After starting all `bpftrace` monitors, wait for probes to be attached.