### PR TITLE
[bm-runner] Cleanup `tmp/benchkit.sh` file after run.

### DIFF
--- a/scripts/run-single.sh
+++ b/scripts/run-single.sh
@@ -42,4 +42,4 @@ ulimit -n $FD_LIMIT
 python3 main.py --title "$TITLE" --config "$CONFIG" $*
 
 # cleanup benchkit file
-sudo rm -f /tmp/benchkit.sh
+rm -f /tmp/benchkit.sh

--- a/scripts/run-single.sh
+++ b/scripts/run-single.sh
@@ -40,3 +40,6 @@ info "Setting the open files limit to $FD_LIMIT"
 ulimit -n $FD_LIMIT
 
 python3 main.py --title "$TITLE" --config "$CONFIG" $*
+
+# cleanup benchkit file
+sudo rm -f /tmp/benchkit.sh


### PR DESCRIPTION
Change

- always remove ` /tmp/benchkit.sh` after running a benchmark
   in `scripts/run-single.sh`. This file can act as lock preventing
   other users from running CSB when created by a different
   user.