### PR TITLE
[bm-runner] main: better handle relative paths

### DIFF
--- a/bm-runner/main.py
+++ b/bm-runner/main.py
@@ -86,6 +86,17 @@ if __name__ == "__main__":
     )
     (args, dir_arg) = parser.parse_known_args()
 
+    # As CSB requires to be at bm-runner dir to run, ensure that all
+    # patches are converted into absolute path.
+    if args.config:
+        args.config = os.path.realpath(os.path.expanduser(args.config))
+    if dir_arg:
+        for i, d in enumerate(dir_arg):
+            dir_arg[i] = os.path.realpath(os.path.expanduser(d)).removesuffix(".csv")
+
+    # Ensure that bm-runner will use bm-runner/ directory
+    os.chdir(os.path.realpath(os.path.dirname(__file__)))
+
     arg_continue = args.replot
     arg_title = args.title if args.title else os.path.basename(args.config).removesuffix(".json")
     arg_config = args.config


### PR DESCRIPTION
Change

- use absolute and real paths for input config/dirs args
- always change `dir` to `bm-runner`
