### PR TITLE
[bm-runner] Introduce `bwrap` as `exec_env`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install pre-requisites
         run: |
           sudo apt update
-          sudo apt-get install -y build-essential cmake libhiredis-dev bubblewrap
+          sudo apt-get install -y build-essential cmake libhiredis-dev bubblewrap uidmap
       - name: Satisfy Specific Prerequisites
         run: |
           ${{ matrix.benchmark.prepare_cmd }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install pre-requisites
         run: |
           sudo apt update
-          sudo apt-get install -y build-essential cmake libhiredis-dev
+          sudo apt-get install -y build-essential cmake libhiredis-dev bubblewrap
       - name: Satisfy Specific Prerequisites
         run: |
           ${{ matrix.benchmark.prepare_cmd }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -143,7 +143,11 @@ jobs:
       - name: Install pre-requisites
         run: |
           sudo apt update
-          sudo apt-get install -y build-essential cmake libhiredis-dev bubblewrap uidmap
+          sudo apt-get install -y build-essential cmake libhiredis-dev bubblewrap
+      - name: Enable bwrap user namespaces
+        run: |
+          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
+          sudo sysctl -w user.max_user_namespaces=15000 || true
       - name: Satisfy Specific Prerequisites
         run: |
           ${{ matrix.benchmark.prepare_cmd }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -146,6 +146,7 @@ jobs:
           sudo apt-get install -y build-essential cmake libhiredis-dev bubblewrap
       - name: Enable bwrap user namespaces
         run: |
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
           sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
           sudo sysctl -w user.max_user_namespaces=15000 || true
       - name: Satisfy Specific Prerequisites

--- a/.github/workflows/docker/openeuler-for-csb.Dockerfile
+++ b/.github/workflows/docker/openeuler-for-csb.Dockerfile
@@ -12,7 +12,7 @@ FROM ${BASE_IMAGE}
 RUN dnf install -y glibc-all-langpacks cmake perf sysstat sudo gcc \
                    moby-engine moby-client hiredis-devel jq \
                    hostname python3 python3-pip iproute lshw ethtool \
-                   nvme-cli hdparm libcgroup-tools sudo git
+                   nvme-cli hdparm libcgroup-tools sudo git bubblewrap
 
 #
 # Reduce container disk space by dropping dnf data

--- a/.github/workflows/openeuler.yml
+++ b/.github/workflows/openeuler.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          - bm_empty
           - rocksdb/rocksdb_aggregated
 
     env:

--- a/bm-runner/benchmark.py
+++ b/bm-runner/benchmark.py
@@ -18,7 +18,7 @@ from bm_executer import Executer
 from utils.logger import bm_log, LogType
 from utils.bm_builder import Builder
 from benchkit.shell.shell import shell_out
-
+from bm_bwrap import Bubblewraps
 
 class ScalabilityBenchmark(Benchmark):
     common_info: dict = {}
@@ -116,6 +116,14 @@ class ScalabilityBenchmark(Benchmark):
                 )
             case ExecutionType.NATIVE:
                 executer = Processes(
+                    config=self.container_cfg,
+                    count=container_cnt,
+                    home_dir=self.csb_dir,
+                    apps=apps,
+                    record_data_dir=record_data_dir,
+                )
+            case ExecutionType.BWRAP:
+                executer = Bubblewraps(
                     config=self.container_cfg,
                     count=container_cnt,
                     home_dir=self.csb_dir,

--- a/bm-runner/benchmark.py
+++ b/bm-runner/benchmark.py
@@ -20,6 +20,7 @@ from utils.bm_builder import Builder
 from benchkit.shell.shell import shell_out
 from bm_bwrap import Bubblewraps
 
+
 class ScalabilityBenchmark(Benchmark):
     common_info: dict = {}
 

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -36,7 +36,7 @@ class Bubblewrap(ExecutionUnit):
         # Inside bwrap, CSB project dir is mounted at /home.
         return str(resolve_path(self.record_data_dir, use_in_container=True))
 
-    def _bwrap_args(self) -> list[str]:
+    def __bwrap_prefix(self) -> list[str]:
         host_home = resolve_path(self.home_dir)
         args: list[str] = [
             "bwrap",
@@ -74,10 +74,14 @@ class Bubblewrap(ExecutionUnit):
             assert self.app.path is not None, "path is not set while change directory is requested!"
             change_dir = f"cd {self.app.path} && "
 
-        # CSB command is a shell string already, so run bash inside bwrap.
+        # # CSB command is a shell string already, so run bash inside bwrap.
         inner_command = f"{self.CMD_WHILE_NOT_START} " f"{change_dir}" f" {command}"
 
-        commands = self._bwrap_args() + ["/bin/bash", "-c", inner_command]
+        commands = self.__bwrap_prefix() + [
+            "/bin/bash",
+            "-c",
+            inner_command
+        ]
 
         self.process = BackgroundProcess(
             name=self.name,
@@ -92,15 +96,14 @@ class Bubblewrap(ExecutionUnit):
         return True
 
     def wait(self):
-        if self.process is None:
-            return
-        returncode = self.process.wait_indefinitely()
-        if returncode != 0:
-            bm_log(
-                f"bwrap process {self.name} failed/crashed with return code {returncode}",
-                LogType.FATAL,
-            )
-            sys.exit(1)
+        if self.process:
+            returncode = self.process.wait_indefinitely()
+            if returncode != 0:
+                bm_log(
+                    f"bwrap process {self.name} failed/crashed with return code {returncode}",
+                    LogType.FATAL,
+                )
+                sys.exit(1)
 
     def stop(self):
         if self.process is not None:

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -1,0 +1,170 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import os
+import resource
+import shlex
+import subprocess
+import sys
+
+from bm_executer import Executer, ExecutionUnit
+from bm_utils import resolve_path, stop_process
+from config.application import Application
+from config.benchmark import ExecutionType
+from config.container import ContainersConfig
+from utils.logger import bm_log, LogType
+
+
+def preexec_process():
+    os.setpgrp()
+    fd_soft, fd_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (fd_hard, fd_hard))
+
+
+class Bubblewrap(ExecutionUnit):
+    def __init__(self, idx, home_dir, record_data_dir, core_set, app: Application):
+        super().__init__(idx=idx, home_dir=home_dir, app=app, type=ExecutionType.BWRAP)
+        self.record_data_dir = record_data_dir
+        self.core_set = core_set
+        self.process = None
+
+    def get_results_dir(self) -> str:
+        # Inside bwrap, CSB project dir is mounted at /home.
+        return str(resolve_path(self.record_data_dir, use_in_container=True))
+
+    def _bwrap_args(self) -> list[str]:
+        host_home = os.path.abspath(self.home_dir)
+
+        args = [
+            "bwrap",
+
+            # Namespace isolation.
+            "--unshare-pid",
+            "--unshare-ipc",
+            "--unshare-uts",
+            "--unshare-cgroup",
+
+            # Keep network shared by default to match current native/container behavior
+            # unless CSB later adds explicit networking policy.
+            "--share-net",
+
+            # Basic runtime filesystems.
+            "--proc", "/proc",
+            "--dev", "/dev",
+            "--tmpfs", "/tmp",
+
+            # Host resources needed by CSB benchmarks.
+            "--bind", host_home, "/home",
+            "--ro-bind", "/usr", "/usr",
+            "--ro-bind", "/bin", "/bin",
+            "--ro-bind", "/lib", "/lib",
+            "--ro-bind", "/lib64", "/lib64",
+
+            # These are writable/readable in current Docker container mode.
+            # Keep them conservative at first; loosen only if specific benchmarks need it.
+            "--ro-bind", "/etc", "/etc",
+
+            "--chdir", "/home",
+        ]
+
+        # Some distros do not have /lib64.
+        args = self._filter_existing_bind_sources(args)
+
+        return args
+
+    @staticmethod
+    def _filter_existing_bind_sources(args: list[str]) -> list[str]:
+        filtered = []
+        i = 0
+        bind_flags = {
+            "--bind",
+            "--ro-bind",
+            "--dev-bind",
+            "--dev-bind-try",
+            "--ro-bind-try",
+            "--bind-try",
+        }
+
+        while i < len(args):
+            item = args[i]
+            if item in bind_flags and i + 2 < len(args):
+                src = args[i + 1]
+                dst = args[i + 2]
+                if item.endswith("-try") or os.path.exists(src):
+                    filtered.extend([item, src, dst])
+                i += 3
+            else:
+                filtered.append(item)
+                i += 1
+
+        return filtered
+
+    def exec(self, command: str) -> bool:
+        change_dir = ""
+        if self.app.cd:
+            assert self.app.path is not None, "path is not set while change directory is requested!"
+            change_dir = f"cd {shlex.quote(self.app.path)} && "
+
+        # CSB command is a shell string already, so run bash inside bwrap.
+        inner_command = (
+            f"{self.CMD_WHILE_NOT_START} "
+            f"{change_dir}"
+            f"taskset --cpu-list {shlex.quote(str(self.core_set))} {command} "
+            f"> {shlex.quote(resolve_path(self.output_file, use_in_container=True))} "
+            f"2> {shlex.quote(resolve_path(self.err_file, use_in_container=True))}"
+        )
+
+        argv = self._bwrap_args() + ["/bin/bash", "-lc", inner_command]
+
+        with open(resolve_path(self.err_file), "w") as err_file:
+            with open(resolve_path(self.output_file), "w") as outfile:
+                self.process = subprocess.Popen(
+                    argv,
+                    stdout=outfile,
+                    stderr=err_file,
+                    preexec_fn=preexec_process,
+                    cwd=self.home_dir,
+                )
+
+        bm_log(f"launched bwrap {self.name} with {' '.join(shlex.quote(x) for x in argv)}")
+        return True
+
+    def wait(self):
+        if self.process is None:
+            return
+
+        self.process.wait()
+        if self.process.returncode != 0:
+            bm_log(
+                f"bwrap process {self.name} failed/crashed with return code {self.process.returncode}",
+                LogType.FATAL,
+            )
+            sys.exit(1)
+
+    def stop(self):
+        if self.process is not None:
+            stop_process(self.process.pid)
+
+
+class Bubblewraps(Executer):
+    def __init__(
+        self,
+        config: ContainersConfig,
+        apps: list[Application],
+        home_dir,
+        count,
+        record_data_dir,
+    ):
+        super().__init__(home_dir=home_dir, results_dir=record_data_dir)
+        assert len(apps) == count, "[BUG] Application list length must be equal to count"
+
+        for i in range(count):
+            core_set = config.get_cpus(i)
+            bwrap = Bubblewrap(
+                idx=i,
+                home_dir=home_dir,
+                core_set=core_set,
+                record_data_dir=record_data_dir,
+                app=apps[i],
+            )
+            self.add_exec_unit(bwrap)

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -74,7 +74,6 @@ class Bubblewrap(ExecutionUnit):
             assert self.app.path is not None, "path is not set while change directory is requested!"
             change_dir = f"cd {self.app.path} && "
 
-        # # CSB command is a shell string already, so run bash inside bwrap.
         inner_command = f"{self.CMD_WHILE_NOT_START} " f"{change_dir}" f" {command}"
 
         commands = self.__bwrap_prefix() + ["/bin/bash", "-c", inner_command]

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -77,11 +77,7 @@ class Bubblewrap(ExecutionUnit):
         # # CSB command is a shell string already, so run bash inside bwrap.
         inner_command = f"{self.CMD_WHILE_NOT_START} " f"{change_dir}" f" {command}"
 
-        commands = self.__bwrap_prefix() + [
-            "/bin/bash",
-            "-c",
-            inner_command
-        ]
+        commands = self.__bwrap_prefix() + ["/bin/bash", "-c", inner_command]
 
         self.process = BackgroundProcess(
             name=self.name,

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -12,6 +12,7 @@ from config.application import Application
 from config.benchmark import ExecutionType
 from config.container import ContainersConfig
 from utils.logger import bm_log, LogType
+from pathlib import Path
 
 
 def preexec_process():
@@ -21,6 +22,15 @@ def preexec_process():
 
 
 class Bubblewrap(ExecutionUnit):
+
+    ro_binding_map: dict[str, str] = {
+        "/usr": "/usr",
+        "/bin": "/bin",
+        "/lib": "/lib",
+        "/lib64": "/lib64",
+        "/etc": "/etc",
+    }
+
     def __init__(self, idx, home_dir, record_data_dir, core_set, app: Application):
         super().__init__(idx=idx, home_dir=home_dir, app=app, type=ExecutionType.BWRAP)
         self.record_data_dir = record_data_dir
@@ -32,9 +42,8 @@ class Bubblewrap(ExecutionUnit):
         return str(resolve_path(self.record_data_dir, use_in_container=True))
 
     def _bwrap_args(self) -> list[str]:
-        host_home = os.path.abspath(self.home_dir)
-
-        args = [
+        host_home = resolve_path(self.home_dir)
+        args: list[str] = [
             "bwrap",
             # Namespace isolation.
             "--unshare-pid",
@@ -53,60 +62,16 @@ class Bubblewrap(ExecutionUnit):
             "/tmp",
             # Host resources needed by CSB benchmarks.
             "--bind",
-            host_home,
+            str(host_home),
             "/home",
-            "--ro-bind",
-            "/usr",
-            "/usr",
-            "--ro-bind",
-            "/bin",
-            "/bin",
-            "--ro-bind",
-            "/lib",
-            "/lib",
-            "--ro-bind",
-            "/lib64",
-            "/lib64",
-            # These are writable/readable in current Docker container mode.
-            # Keep them conservative at first; loosen only if specific benchmarks need it.
-            "--ro-bind",
-            "/etc",
-            "/etc",
             "--chdir",
             "/home",
         ]
-
-        # Some distros do not have /lib64.
-        args = self._filter_existing_bind_sources(args)
+        for src, dst in self.ro_binding_map.items():
+            if os.path.exists(Path(src)):
+                args.extend(["--ro-bind", src, dst])
 
         return args
-
-    @staticmethod
-    def _filter_existing_bind_sources(args: list[str]) -> list[str]:
-        filtered = []
-        i = 0
-        bind_flags = {
-            "--bind",
-            "--ro-bind",
-            "--dev-bind",
-            "--dev-bind-try",
-            "--ro-bind-try",
-            "--bind-try",
-        }
-
-        while i < len(args):
-            item = args[i]
-            if item in bind_flags and i + 2 < len(args):
-                src = args[i + 1]
-                dst = args[i + 2]
-                if item.endswith("-try") or os.path.exists(src):
-                    filtered.extend([item, src, dst])
-                i += 3
-            else:
-                filtered.append(item)
-                i += 1
-
-        return filtered
 
     def exec(self, command: str) -> bool:
         change_dir = ""
@@ -121,7 +86,7 @@ class Bubblewrap(ExecutionUnit):
             f"taskset --cpu-list {self.core_set} {command}"
         )
 
-        commands = self._bwrap_args() + ["/bin/bash", "-lc", inner_command]
+        commands = self._bwrap_args() + ["/bin/bash", "-c", inner_command]
 
         with open(resolve_path(self.err_file), "w") as err_file:
             with open(resolve_path(self.output_file), "w") as outfile:

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -2,23 +2,16 @@
 # SPDX-License-Identifier: MIT
 
 import os
-import resource
-import subprocess
 import sys
 
 from bm_executer import Executer, ExecutionUnit
-from bm_utils import resolve_path, stop_process
+from bm_utils import resolve_path
 from config.application import Application
 from config.benchmark import ExecutionType
 from config.container import ContainersConfig
 from utils.logger import bm_log, LogType
 from pathlib import Path
-
-
-def preexec_process():
-    os.setpgrp()
-    fd_soft, fd_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (fd_hard, fd_hard))
+from utils.process import BackgroundProcess
 
 
 class Bubblewrap(ExecutionUnit):
@@ -80,42 +73,36 @@ class Bubblewrap(ExecutionUnit):
             change_dir = f"cd {self.app.path} && "
 
         # CSB command is a shell string already, so run bash inside bwrap.
-        inner_command = (
-            f"{self.CMD_WHILE_NOT_START} "
-            f"{change_dir}"
-            f"taskset --cpu-list {self.core_set} {command}"
-        )
+        inner_command = f"{self.CMD_WHILE_NOT_START} " f"{change_dir}" f" {command}"
 
         commands = self._bwrap_args() + ["/bin/bash", "-c", inner_command]
 
-        with open(resolve_path(self.err_file), "w") as err_file:
-            with open(resolve_path(self.output_file), "w") as outfile:
-                self.process = subprocess.Popen(
-                    commands,
-                    stdout=outfile,
-                    stderr=err_file,
-                    preexec_fn=preexec_process,
-                    cwd=self.home_dir,
-                )
-
-        bm_log(f"launched bwrap {self.name} with {commands}")
+        self.process = BackgroundProcess(
+            name=self.name,
+            cmds=commands,
+            out_dir=str(resolve_path(Path(self.output_file).parent)),
+            efile_name=Path(self.err_file).name,
+            ofile_name=Path(self.output_file).name,
+            wdir=self.home_dir,
+            pin=self.core_set,
+        )
+        self.process.start()
         return True
 
     def wait(self):
         if self.process is None:
             return
-
-        self.process.wait()
-        if self.process.returncode != 0:
+        returncode = self.process.wait_indefinitely()
+        if returncode != 0:
             bm_log(
-                f"bwrap process {self.name} failed/crashed with return code {self.process.returncode}",
+                f"bwrap process {self.name} failed/crashed with return code {returncode}",
                 LogType.FATAL,
             )
             sys.exit(1)
 
     def stop(self):
         if self.process is not None:
-            stop_process(self.process.pid)
+            self.process.force_stop()
 
 
 class Bubblewraps(Executer):

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -12,6 +12,7 @@ from config.container import ContainersConfig
 from utils.logger import bm_log, LogType
 from pathlib import Path
 from utils.process import BackgroundProcess
+from bm_utils import ensure_exists
 
 
 class Bubblewrap(ExecutionUnit):
@@ -29,6 +30,7 @@ class Bubblewrap(ExecutionUnit):
         self.record_data_dir = record_data_dir
         self.core_set = core_set
         self.process = None
+        ensure_exists("bwrap")
 
     def get_results_dir(self) -> str:
         # Inside bwrap, CSB project dir is mounted at /home.

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -3,7 +3,6 @@
 
 import os
 import resource
-import shlex
 import subprocess
 import sys
 
@@ -37,34 +36,44 @@ class Bubblewrap(ExecutionUnit):
 
         args = [
             "bwrap",
-
             # Namespace isolation.
             "--unshare-pid",
             "--unshare-ipc",
             "--unshare-uts",
             "--unshare-cgroup",
-
             # Keep network shared by default to match current native/container behavior
             # unless CSB later adds explicit networking policy.
             "--share-net",
-
             # Basic runtime filesystems.
-            "--proc", "/proc",
-            "--dev", "/dev",
-            "--tmpfs", "/tmp",
-
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--tmpfs",
+            "/tmp",
             # Host resources needed by CSB benchmarks.
-            "--bind", host_home, "/home",
-            "--ro-bind", "/usr", "/usr",
-            "--ro-bind", "/bin", "/bin",
-            "--ro-bind", "/lib", "/lib",
-            "--ro-bind", "/lib64", "/lib64",
-
+            "--bind",
+            host_home,
+            "/home",
+            "--ro-bind",
+            "/usr",
+            "/usr",
+            "--ro-bind",
+            "/bin",
+            "/bin",
+            "--ro-bind",
+            "/lib",
+            "/lib",
+            "--ro-bind",
+            "/lib64",
+            "/lib64",
             # These are writable/readable in current Docker container mode.
             # Keep them conservative at first; loosen only if specific benchmarks need it.
-            "--ro-bind", "/etc", "/etc",
-
-            "--chdir", "/home",
+            "--ro-bind",
+            "/etc",
+            "/etc",
+            "--chdir",
+            "/home",
         ]
 
         # Some distros do not have /lib64.
@@ -103,30 +112,28 @@ class Bubblewrap(ExecutionUnit):
         change_dir = ""
         if self.app.cd:
             assert self.app.path is not None, "path is not set while change directory is requested!"
-            change_dir = f"cd {shlex.quote(self.app.path)} && "
+            change_dir = f"cd {self.app.path} && "
 
         # CSB command is a shell string already, so run bash inside bwrap.
         inner_command = (
             f"{self.CMD_WHILE_NOT_START} "
             f"{change_dir}"
-            f"taskset --cpu-list {shlex.quote(str(self.core_set))} {command} "
-            f"> {shlex.quote(resolve_path(self.output_file, use_in_container=True))} "
-            f"2> {shlex.quote(resolve_path(self.err_file, use_in_container=True))}"
+            f"taskset --cpu-list {self.core_set} {command}"
         )
 
-        argv = self._bwrap_args() + ["/bin/bash", "-lc", inner_command]
+        commands = self._bwrap_args() + ["/bin/bash", "-lc", inner_command]
 
         with open(resolve_path(self.err_file), "w") as err_file:
             with open(resolve_path(self.output_file), "w") as outfile:
                 self.process = subprocess.Popen(
-                    argv,
+                    commands,
                     stdout=outfile,
                     stderr=err_file,
                     preexec_fn=preexec_process,
                     cwd=self.home_dir,
                 )
 
-        bm_log(f"launched bwrap {self.name} with {' '.join(shlex.quote(x) for x in argv)}")
+        bm_log(f"launched bwrap {self.name} with {commands}")
         return True
 
     def wait(self):

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -11,7 +11,7 @@ from abc import abstractmethod
 from config.plugin import ExecutionTime
 import bm_config
 from config.application import Application
-from config.benchmark import ExecutionType
+from config.benchmark import ExecutionType, EXECUTION_TYPE_PREFIX
 from bm_utils import is_port_free_to_use
 from monitors.monitor_factory import MonitorFactory
 from utils.logger import bm_log, LogType
@@ -28,7 +28,7 @@ class ExecutionUnit:
         self.idx = idx
         self.type = type
         self.home_dir = home_dir
-        self.name = "C" if type == ExecutionType.CONTAINER else "N"
+        self.name = EXECUTION_TYPE_PREFIX[type]
         self.name += f"{idx:03d}_{app.name}"
         self.output_file = os.path.join(Application.BUILTIN_APP_DIR, self.name)
         self.err_file = os.path.join(Application.BUILTIN_APP_DIR, f"{self.name}_err")

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -18,13 +18,15 @@ class ExecutionType(str, Enum):
 
     NATIVE = "native"  # indicates that the benchmark should run natively
     CONTAINER = "container"  # indicates that the benchmark should run inside the container
-    BWRAP = "bwrap" # indicates that the benchmark should run with bubblewrap
+    BWRAP = "bwrap"  # indicates that the benchmark should run with bubblewrap
+
 
 EXECUTION_TYPE_PREFIX = {
-    ExecutionType.CONTAINER : "C",
-    ExecutionType.NATIVE : "N",
-    ExecutionType.BWRAP : "B",
+    ExecutionType.CONTAINER: "C",
+    ExecutionType.NATIVE: "N",
+    ExecutionType.BWRAP: "B",
 }
+
 
 class MonitorType(str, Enum):
     """

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -18,6 +18,7 @@ class ExecutionType(str, Enum):
 
     NATIVE = "native"  # indicates that the benchmark should run natively
     CONTAINER = "container"  # indicates that the benchmark should run inside the container
+    BWRAP = "bwrap" # indicates that the benchmark should run with bubblewrap
 
 
 class MonitorType(str, Enum):

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -20,6 +20,11 @@ class ExecutionType(str, Enum):
     CONTAINER = "container"  # indicates that the benchmark should run inside the container
     BWRAP = "bwrap" # indicates that the benchmark should run with bubblewrap
 
+EXECUTION_TYPE_PREFIX = {
+    ExecutionType.CONTAINER : "C",
+    ExecutionType.NATIVE : "N",
+    ExecutionType.BWRAP : "B",
+}
 
 class MonitorType(str, Enum):
     """

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -14,6 +14,7 @@ class ExecutionType(str, Enum):
     ----------
     NATIVE: Launches the benchmark(s) directly on the host OS.
     CONTAINER: Launches the benchmark(s) inside a container.
+    BWRAP: Launches the benchmark(s) with bubblewrap.
     """
 
     NATIVE = "native"  # indicates that the benchmark should run natively

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -24,7 +24,7 @@ class BackgroundProcess:
         wdir: Optional[str] = None,
         ofile_name: Optional[str] = None,
         efile_name: Optional[str] = None,
-        pin: Optional[list[int]] = None,
+        pin: Optional[list[int] | str] = None,
         requires: list[str] = [],
     ):
         """
@@ -44,9 +44,10 @@ class BackgroundProcess:
             The name of the file to save `stdout` to. If not provided, a given `name` with a `.log` extension will be used.
         efile_name: Optional[str]
             The name of the file to save `stderr` to. If not provided, a given `name` with a `.err` extension will be used.
-        pin: Optional[list[int]]
+        pin: Optional[list[int]|str]
             Optional list of CPUs to assign to the process with taskset.
             If None, the process will not be assigned specific CPUs.
+            If str, it should be comma delimited list of ints e.g. "1,2,4".
         requires: list[str]
             A list of required applications that must be available for the launch to succeed. Each application is checked for existence.
         """
@@ -68,8 +69,14 @@ class BackgroundProcess:
         if pin is None:
             self.cmds = cmds
         else:
-            cpus = ",".join([str(c) for c in pin])
-            cmd_prefix = ["taskset", "--cpu-list", cpus]
+            cpus_str: str = ""
+            if isinstance(pin, list):
+                cpus_str = ",".join([str(c) for c in pin])
+            else:
+                assert isinstance(pin, str), "Type is not supported!"
+                cpus_str = pin
+
+            cmd_prefix = ["taskset", "--cpu-list", cpus_str]
             self.cmds = cmd_prefix + cmds
 
         # ensure process exist

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -124,7 +124,7 @@ class BackgroundProcess:
         """
         Kills the process and whatever children the process spawned.
         """
-        if self.process:
+        if self.process and self.process.poll() is None:
             bm_log(f"Killing {self.name}, with PID = {self.process.pid}")
             stop_process(self.process.pid)
 

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -9,6 +9,7 @@ from typing import Optional
 from bm_utils import ensure_exists
 from bm_utils import stop_process
 import time
+import resource
 
 
 class BackgroundProcess:
@@ -75,11 +76,19 @@ class BackgroundProcess:
         for tool in requires:
             ensure_exists(tool)
 
+    @staticmethod
+    def __preexec_fn():
+        os.setpgrp()
+        fd_soft, fd_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (fd_hard, fd_hard))
+
     def start(self):
         """
         Starts the process in the background.
         """
         assert self.process is None, "it seems, it has already been started!"
+        bm_log(f"{self.ofile_name}", LogType.ERROR)
+        bm_log(f"{self.efile_name}", LogType.ERROR)
         self.ofile = open(self.ofile_name, "w")
         self.efile = open(self.efile_name, "w")
         self.process = subprocess.Popen(
@@ -87,7 +96,7 @@ class BackgroundProcess:
             stdout=self.ofile,
             stderr=self.efile,
             env=self.Env,
-            preexec_fn=os.setpgrp,
+            preexec_fn=self.__preexec_fn,
             cwd=self.wdir,
         )
         cmd_str = " ".join(self.cmds)
@@ -125,17 +134,17 @@ class BackgroundProcess:
         bm_log(f"{self.name} is not alive!", LogType.ERROR)
         return False
 
-    def wait_indefinitely(self):
+    def wait_indefinitely(self) -> int:
         """
         Waits for the process to finish without timeout.
         This method can block for a long time and will not attempt to cancel or terminate the process.
         """
         if self.process is None:
-            return
+            return 0
         bm_log(
             f"Waiting for {self.name} without timeout, with PID = {self.process.pid} to terminate"
         )
-        self.process.wait()
+        return self.process.wait()
 
     def stop(self, timeout=TIMEOUT_SEC) -> int:
         """

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -87,8 +87,6 @@ class BackgroundProcess:
         Starts the process in the background.
         """
         assert self.process is None, "it seems, it has already been started!"
-        bm_log(f"{self.ofile_name}", LogType.ERROR)
-        bm_log(f"{self.efile_name}", LogType.ERROR)
         self.ofile = open(self.ofile_name, "w")
         self.efile = open(self.efile_name, "w")
         self.process = subprocess.Popen(

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -42,13 +42,14 @@
         ]
       ]
     },
-    "duration": 1
+    "duration": 1,
+    "exec_env": ["bwrap", "native", "container"]
   },
   "containers": {
     "core_assignment_policy": {
       "cpu_order": "desc",
       "pack_group": "none",
-      "one_cpu_per_core": false
+      "one_cpu_per_core": true
     }
   },
   "applications": [

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -43,7 +43,11 @@
       ]
     },
     "duration": 1,
-    "exec_env": ["bwrap"]
+    "exec_env": [
+      "bwrap",
+      "native",
+      "container"
+    ]
   },
   "containers": {
     "core_assignment_policy": {
@@ -51,7 +55,7 @@
       "pack_group": "none",
       "one_cpu_per_core": true
     },
-    "container_list" : {"values":[[1, 10]]}
+    "core_count": 2
   },
   "applications": [
     {

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -43,7 +43,7 @@
       ]
     },
     "duration": 1,
-    "exec_env": ["bwrap", "native", "container"]
+    "exec_env": ["bwrap"]
   },
   "containers": {
     "core_assignment_policy": {

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -50,7 +50,8 @@
       "cpu_order": "desc",
       "pack_group": "none",
       "one_cpu_per_core": true
-    }
+    },
+    "container_list" : {"values":[[1, 10]]}
   },
   "applications": [
     {

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -142,6 +142,7 @@ Execution time of the plugin script/process.  <br/>Supported values:
 Execution environment of the benchmarks.  <br/>Supported values:
 - `"native"`:  Launches the benchmark(s) directly on the host OS.
 - `"container"`:  Launches the benchmark(s) inside a container.
+- `"bwrap"`:  Launches the benchmark(s) with bubblewrap.
 ## CpuOrder
 Supported CPU orders.  <br/>Supported values:
 - `"asc"`:  Assign CPUs in ascending order.


### PR DESCRIPTION
Add

- `bm_bwrap` for running benchmarks with bubblewrap.

Change

- Add `bwrap` as new `ExecutionType`
- `BackgroundProcess` accept `pin` as string as well. 
- install bubblewrap to CI runner