### PR TITLE
[bm-runner] Allow changing `palette` via `PlotConfig`.

### DIFF
--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -31,7 +31,7 @@ class PlotType(str, Enum):
     BPFTRACE_HIST = "bpftrace_hist"
 
 
-PlotPalette: TypeAlias = list
+PlotPalette: TypeAlias = sns.palettes._ColorPalette
 
 
 class PlotConfig(dict):

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Optional
 from typing import TypeAlias
 
+import seaborn as sns
 
 class PlotType(str, Enum):
     """

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -3,6 +3,7 @@
 
 from enum import Enum
 from typing import Optional
+from typing import TypeAlias
 
 
 class PlotType(str, Enum):
@@ -29,6 +30,9 @@ class PlotType(str, Enum):
     BPFTRACE_HIST = "bpftrace_hist"
 
 
+PlotPalette: TypeAlias = list
+
+
 class PlotConfig(dict):
     CONFIG_KEY: str = "plots"
 
@@ -53,6 +57,7 @@ class PlotConfig(dict):
         title: Optional[str] = None,
         shape: Optional[str] = None,
         type: PlotType = PlotType.NORMAL,
+        palette: str | PlotPalette = "hls",
     ):
         """
         Plot configuration for benchmark results.
@@ -78,6 +83,8 @@ class PlotConfig(dict):
             The shape/type of the plot (e.g., 'lineplot', 'barplot'). If None, defaults based on `type`.
         type: PlotType
             The type of plot to be created, which determines default shape and other behaviors.
+        palette: str
+            The color palette to use for the plot.
         -
         """
         super().__init__(
@@ -90,6 +97,7 @@ class PlotConfig(dict):
             title=title,
             shape=shape,
             type=type,
+            palette=palette,
         )
         self.x = x
         self.y = y
@@ -100,3 +108,7 @@ class PlotConfig(dict):
         self.title = title if title is not None else f"{self.x_lbl} vs. {self.y_lbl}"
         self.type = type
         self.shape = shape if shape is not None else self.DEFAULT_PLOT[self.type]
+        self.palette = palette
+
+    def set_palette(self, palette: PlotPalette | str):
+        self.palette = palette

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -7,6 +7,7 @@ from typing import TypeAlias
 
 import seaborn as sns
 
+
 class PlotType(str, Enum):
     """
     Supported types of plots.

--- a/bm-runner/visual/plotchart.py
+++ b/bm-runner/visual/plotchart.py
@@ -28,7 +28,10 @@ class PlotChart:
         # prep hue, we want to generate enough colors
         cnt = df[plot.hue].nunique()
         sorted_gp = sorted(df[plot.hue].unique())
-        palette = sns.color_palette(palette="hls", n_colors=cnt)
+        if isinstance(plot.palette, str):
+            palette = sns.color_palette(palette=plot.palette, n_colors=cnt)
+        else:
+            palette = plot.palette
         sns_plot_fun = getattr(sns, plot.shape)
 
         if (

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -8,7 +8,8 @@
       "hue_lbl": "Executer",
       "hue": "execution_unit",
       "shape": "barplot",
-      "title": "Throughput vs. #Containers"
+      "title": "Throughput vs. #Containers",
+      "palette": "rocket"
     },
     {
       "x": "container_cnt",

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -72,6 +72,7 @@ Plot configuration for benchmark results. Represented as a JSON array of objects
 |title|str|:white_check_mark:|`{x_lbl} vs. {y_lbl}`|    The title of the plot. If None, defaults to `{x_lbl} vs. {y_lbl}`. |
 |shape|str|:white_check_mark:||    The shape/type of the plot (e.g., 'lineplot', 'barplot'). If None, defaults based on `type`. |
 |type|[PlotType](#plottype)|:white_check_mark:|`normal`|    The type of plot to be created, which determines default shape and other behaviors. |
+|palette|UnionType[str, list]|:white_check_mark:|`hls`|    The color palette to use for the plot. |
 
 ## NicsConfig
 NicsConfig configures the assignment of Network Interface Cards (NICs) or their Virtual Functions (VFs) to containers. Represented as a JSON object. 

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -72,7 +72,7 @@ Plot configuration for benchmark results. Represented as a JSON array of objects
 |title|str|:white_check_mark:|`{x_lbl} vs. {y_lbl}`|    The title of the plot. If None, defaults to `{x_lbl} vs. {y_lbl}`. |
 |shape|str|:white_check_mark:||    The shape/type of the plot (e.g., 'lineplot', 'barplot'). If None, defaults based on `type`. |
 |type|[PlotType](#plottype)|:white_check_mark:|`normal`|    The type of plot to be created, which determines default shape and other behaviors. |
-|palette|UnionType[str, list]|:white_check_mark:|`hls`|    The color palette to use for the plot. |
+|palette|UnionType[str, _ColorPalette]|:white_check_mark:|`hls`|    The color palette to use for the plot. |
 
 ## NicsConfig
 NicsConfig configures the assignment of Network Interface Cards (NICs) or their Virtual Functions (VFs) to containers. Represented as a JSON object. 


### PR DESCRIPTION
Change

- Users can overwrite the default `palette` of the plot using
   JSON config.
- Developers can overwrite the given or default `palette`  using
  `set_palette` method of `PlotConfig`