### PR TITLE
[bm-runner] Refactor and reduce redundant code.

### DIFF
--- a/bm-runner/benchmark.py
+++ b/bm-runner/benchmark.py
@@ -10,15 +10,12 @@ import sys
 from typing import Optional, Dict, Any, List
 import bm_utils
 from bm_utils import get_cgroups_version
-from bm_container import Containers
-from bm_process import Processes
 from config.benchmark import ExecutionType
 import bm_config
 from bm_executer import Executer
 from utils.logger import bm_log, LogType
 from utils.bm_builder import Builder
 from benchkit.shell.shell import shell_out
-from bm_bwrap import Bubblewraps
 
 
 class ScalabilityBenchmark(Benchmark):
@@ -105,36 +102,15 @@ class ScalabilityBenchmark(Benchmark):
         port_start = self.container_cfg.port
         # assign an app per container, this is relevant when there are multiple apps
         apps = [applications[i % len(applications)] for i in range(container_cnt)]
-        executer: Executer
-        match execution_type:
-            case ExecutionType.CONTAINER:
-                executer = Containers(
-                    config=self.container_cfg,
-                    count=container_cnt,
-                    home_dir=self.csb_dir,
-                    apps=apps,
-                    record_data_dir=record_data_dir,
-                )
-            case ExecutionType.NATIVE:
-                executer = Processes(
-                    config=self.container_cfg,
-                    count=container_cnt,
-                    home_dir=self.csb_dir,
-                    apps=apps,
-                    record_data_dir=record_data_dir,
-                )
-            case ExecutionType.BWRAP:
-                executer = Bubblewraps(
-                    config=self.container_cfg,
-                    count=container_cnt,
-                    home_dir=self.csb_dir,
-                    apps=apps,
-                    record_data_dir=record_data_dir,
-                )
-            case _:
-                bm_log(f"Unsupported execution type = {execution_type}", LogType.FATAL)
-                sys.exit(1)
-        assert executer is not None
+        executer = Executer(
+            config=self.container_cfg,
+            count=container_cnt,
+            home_dir=self.csb_dir,
+            apps=apps,
+            results_dir=record_data_dir,
+            type=execution_type,
+        )
+
         executer.exec_all(
             threads=nb_threads,
             duration=benchmark_duration_seconds,

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-from bm_executer import ExecutionUnit
+from bm_exec_unit import ExecutionUnit
 from bm_utils import resolve_path
 from config.application import Application
 from config.benchmark import ExecutionType

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -4,11 +4,10 @@
 import os
 import sys
 
-from bm_executer import Executer, ExecutionUnit
+from bm_executer import ExecutionUnit
 from bm_utils import resolve_path
 from config.application import Application
 from config.benchmark import ExecutionType
-from config.container import ContainersConfig
 from utils.logger import bm_log, LogType
 from pathlib import Path
 from utils.process import BackgroundProcess
@@ -103,27 +102,3 @@ class Bubblewrap(ExecutionUnit):
     def stop(self):
         if self.process is not None:
             self.process.force_stop()
-
-
-class Bubblewraps(Executer):
-    def __init__(
-        self,
-        config: ContainersConfig,
-        apps: list[Application],
-        home_dir,
-        count,
-        record_data_dir,
-    ):
-        super().__init__(home_dir=home_dir, results_dir=record_data_dir)
-        assert len(apps) == count, "[BUG] Application list length must be equal to count"
-
-        for i in range(count):
-            core_set = config.get_cpus(i)
-            bwrap = Bubblewrap(
-                idx=i,
-                home_dir=home_dir,
-                core_set=core_set,
-                record_data_dir=record_data_dir,
-                app=apps[i],
-            )
-            self.add_exec_unit(bwrap)

--- a/bm-runner/bm_container.py
+++ b/bm-runner/bm_container.py
@@ -14,8 +14,7 @@ import bm_utils
 from textwrap import indent
 from typing import Optional
 from config.application import Application
-from config.container import ContainersConfig
-from config.nics import NicsConfig, ContainerNicConfig
+from config.nics import ContainerNicConfig
 from config.benchmark import ExecutionType
 from utils.logger import bm_log, LogType
 from bm_utils import resolve_path
@@ -227,30 +226,3 @@ class Container(ExecutionUnit):
             command = f"cd {self.app.path} && {command}"
         commands = f"{self.CMD_WHILE_NOT_START} {command} > {resolve_path(self.output_file, use_in_container=True)} 2> {resolve_path(self.err_file, use_in_container=True)}"  # same as self.output_file outside container.
         return self.__start(commands)
-
-
-class Containers(Executer):
-    def __init__(
-        self,
-        config: ContainersConfig,
-        apps: list[Application],
-        home_dir,
-        count,
-        record_data_dir,
-        nics: Optional[NicsConfig] = None,
-    ):
-        super().__init__(home_dir, results_dir=record_data_dir)
-        assert len(apps) == count, "[BUG] Application list length must be equal to count"
-        for i in range(count):
-            core_set = config.get_cpus(i)
-            container = Container(
-                idx=i,
-                home_dir=home_dir,
-                image=config.image,
-                core_set=core_set,
-                record_data_dir=record_data_dir,
-                port=config.port,
-                app=apps[i],
-                nic=self.nics.get_cfg(i) if self.nics else None,
-            )
-            self.add_exec_unit(container)

--- a/bm-runner/bm_container.py
+++ b/bm-runner/bm_container.py
@@ -8,7 +8,6 @@ import os
 import time
 import sys
 from benchkit.shell.shell import shell_out
-from bm_executer import Executer
 from bm_exec_unit import ExecutionUnit
 import bm_utils
 from textwrap import indent

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -89,6 +89,7 @@ class Executer:
                     record_data_dir=self.results_dir,
                     port=self.config.port,
                     app=self.apps[idx],
+                    nic=self.nics.get_cfg(idx) if self.nics else None,
                 )
             case ExecutionType.NATIVE:
                 return Process(

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -13,23 +13,45 @@ from bm_utils import is_port_free_to_use
 from monitors.monitor_factory import MonitorFactory
 from utils.logger import bm_log, LogType
 from bm_utils import resolve_path
+<<<<<<< HEAD
 from bm_exec_unit import ExecutionUnit
+=======
+from config.container import ContainersConfig
+from bm_process import Process
+from bm_container import Container
+from bm_bwrap import Bubblewrap
+>>>>>>> 77934ee (refactor)
 
 
 class Executer:
     SLEEP_IN_SEC = 5
 
-    def __init__(self, home_dir, results_dir):
+    def __init__(
+        self,
+        config: ContainersConfig,
+        type: ExecutionType,
+        apps: list[Application],
+        home_dir,
+        results_dir,
+        count: int,
+    ):
         assert bm_config.g_config
         self.home_dir = home_dir
         self.results_dir = results_dir
         self.exec_units = []
         self.plugins = bm_config.g_config.get_plugins()
         self.nics = bm_config.g_config.get_nics()
+        self.config = config
+        self.apps = apps
+        self.count = count
         self.monitors = [
             MonitorFactory.create(monitor_type=type, results_dir=results_dir, args=args)
             for type, args in bm_config.g_config.get_benchmark_cfg().monitors.items()
         ]
+        assert len(apps) >= count, "#apps should be >= count"
+        for idx in range(self.count):
+            eu = self.__create_eu(type, idx)
+            self.add_exec_unit(eu)
 
     def __call_plugins(self, exec_time):
         plugins = [plugin for plugin in self.plugins if plugin.exec_time == exec_time]
@@ -56,6 +78,39 @@ class Executer:
             if plugin.exec_time == ExecutionTime.WITH
         ]
         return " ".join(plugins)
+
+    def __create_eu(self, type: ExecutionType, idx: int) -> ExecutionUnit:
+        core_set = self.config.get_cpus(idx)
+        match type:
+            case ExecutionType.CONTAINER:
+                return Container(
+                    idx=idx,
+                    home_dir=self.home_dir,
+                    image=self.config.image,
+                    core_set=core_set,
+                    record_data_dir=self.results_dir,
+                    port=self.config.port,
+                    app=self.apps[idx],
+                )
+            case ExecutionType.NATIVE:
+                return Process(
+                    idx=idx,
+                    home_dir=self.home_dir,
+                    core_set=core_set,
+                    record_data_dir=self.results_dir,
+                    app=self.apps[idx],
+                )
+            case ExecutionType.BWRAP:
+                return Bubblewrap(
+                    idx=idx,
+                    home_dir=self.home_dir,
+                    core_set=core_set,
+                    record_data_dir=self.results_dir,
+                    app=self.apps[idx],
+                )
+            case _:
+                bm_log(f"Unsupported execution type = {type}", LogType.FATAL)
+                sys.exit(1)
 
     def add_exec_unit(self, unit):
         self.exec_units.append(unit)

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -46,10 +46,10 @@ class Executer:
             MonitorFactory.create(monitor_type=type, results_dir=results_dir, args=args)
             for type, args in bm_config.g_config.get_benchmark_cfg().monitors.items()
         ]
-        assert len(apps) >= count, "#apps should be >= count"
+        assert len(apps) == count, "[BUG] Application list length must be equal to count"
         for idx in range(self.count):
             eu = self.__create_eu(type, idx)
-            self.add_exec_unit(eu)
+            self.exec_units.append(eu)
 
     def __call_plugins(self, exec_time):
         plugins = [plugin for plugin in self.plugins if plugin.exec_time == exec_time]
@@ -110,9 +110,6 @@ class Executer:
             case _:
                 bm_log(f"Unsupported execution type = {type}", LogType.FATAL)
                 sys.exit(1)
-
-    def add_exec_unit(self, unit):
-        self.exec_units.append(unit)
 
     def __stop_plugins(self):
         for plugin in self.plugins:

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -13,14 +13,12 @@ from bm_utils import is_port_free_to_use
 from monitors.monitor_factory import MonitorFactory
 from utils.logger import bm_log, LogType
 from bm_utils import resolve_path
-<<<<<<< HEAD
-from bm_exec_unit import ExecutionUnit
-=======
 from config.container import ContainersConfig
 from bm_process import Process
 from bm_container import Container
 from bm_bwrap import Bubblewrap
->>>>>>> 77934ee (refactor)
+from bm_exec_unit import ExecutionUnit, ExecutionType
+from config.application import Application
 
 
 class Executer:

--- a/bm-runner/bm_process.py
+++ b/bm-runner/bm_process.py
@@ -5,7 +5,6 @@ import os
 import resource
 import sys
 import subprocess
-from bm_executer import Executer
 from bm_exec_unit import ExecutionUnit
 from bm_utils import stop_process
 from bm_config import Application

--- a/bm-runner/bm_process.py
+++ b/bm-runner/bm_process.py
@@ -12,7 +12,6 @@ from bm_config import Application
 from config.benchmark import ExecutionType
 from utils.logger import bm_log, LogType
 from bm_utils import resolve_path
-from config.container import ContainersConfig
 
 
 def preexec_process():
@@ -67,26 +66,3 @@ class Process(ExecutionUnit):
     def stop(self):
         if self.process is not None:
             stop_process(self.process.pid)
-
-
-class Processes(Executer):
-    def __init__(
-        self,
-        config: ContainersConfig,
-        apps: list[Application],
-        home_dir,
-        count,
-        record_data_dir,
-    ):
-        super().__init__(home_dir=home_dir, results_dir=record_data_dir)
-        assert len(apps) == count, "[BUG] Application list length must be equal to count"
-        for i in range(count):
-            core_set = config.get_cpus(i)
-            proc = Process(
-                idx=i,
-                home_dir=home_dir,
-                core_set=core_set,
-                record_data_dir=record_data_dir,
-                app=apps[i],
-            )
-            self.add_exec_unit(proc)

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -314,7 +314,7 @@ def create_plot(df, plot: PlotConfig, dir, info: str) -> str:
             return BpfTrace.dump_hist_data_heat_map(df=df, plot=plot, output_dir=dir)
         case _:
             bm_log(f"unsupported plot type: {plot.type} skipped!", LogType.WARNING)
-            return None
+            return ""
 
 
 ###########################################################################


### PR DESCRIPTION
Change

- drop classes `Bubblewraps`, `Containers`, `Processes`. Let 
  Executer handle `ExecutionUnit` creation based on the given type
  instead. The logic stays intact.