### PR TITLE
[bm-runner] Support passing execution env arguments.

### DIFF
--- a/bm-generator/templates/fg_single.json.in
+++ b/bm-generator/templates/fg_single.json.in
@@ -33,7 +33,9 @@
 	],
 	"benchmark_config" : {
 		"duration": 60,
-		"exec_env": ["native"],
+		"exec_env": {
+      		"native" : []
+    	},
 		"monitors" : {"perf" : ["-C", "0"]}
 	},
 	"containers": {

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -12,6 +12,7 @@ from utils.logger import bm_log, LogType
 from pathlib import Path
 from utils.process import BackgroundProcess
 from bm_utils import ensure_exists
+import bm_config
 
 
 class Bubblewrap(ExecutionUnit):
@@ -65,6 +66,9 @@ class Bubblewrap(ExecutionUnit):
             if os.path.exists(Path(src)):
                 args.extend(["--ro-bind", src, dst])
 
+        assert bm_config.g_config, "Unexpected error, configuration object is not set!"
+        cfg = bm_config.g_config.get_benchmark_cfg()
+        args.extend(cfg.get_exec_env_args(ExecutionType.BWRAP))
         return args
 
     def exec(self, command: str) -> bool:

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -92,9 +92,11 @@ class BenchmarkConfig(dict):
             How many `nop` operations to run between real
             operations.
             JSON example: `"noise" : [0, 1000]`
-        exec_env: list[ExecutionType] = ["native", "container"]
-            Whether to execute the benchmark in a container or
-            natively. JSON example: `"exec_env" : ["container", "native"]`
+        exec_env: dict[ExecutionType, list[str]] = {"native":[], "container":[]}
+            Dictates in which environments the benchmark is executed, and which
+            extra arguments are used. Note that currently the arguments are
+            only considered in case of `bwrap`.
+            JSON example: `"exec_env" : {"native":[], "container":[], "bwrap":["--die-with-parent"]}`
         monitors: dict[MonitorType, list[str]]
             Monitors to run in the background.
         threads: ListConfig = {"values": [[1]]}

--- a/bm-runner/config/benchmark.py
+++ b/bm-runner/config/benchmark.py
@@ -65,7 +65,10 @@ class BenchmarkConfig(dict):
         repeat: int = 1,
         initial_size: list[int] = [0],
         noise: list[int] = [0],
-        exec_env: list[ExecutionType] = [ExecutionType.NATIVE, ExecutionType.CONTAINER],
+        exec_env: dict[ExecutionType, list[str]] = {
+            ExecutionType.NATIVE: [],
+            ExecutionType.CONTAINER: [],
+        },
         monitors: dict[MonitorType, list[str]] = {},
         threads: Optional[ListConfig] = None,
     ):
@@ -110,3 +113,6 @@ class BenchmarkConfig(dict):
             if threads is not None
             else ListConfig([[1]]).get_list()
         )
+
+    def get_exec_env_args(self, exec_type: ExecutionType) -> list[str]:
+        return self.exec_env.get(exec_type, [])

--- a/bm-runner/main.py
+++ b/bm-runner/main.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
         benchmark_duration_seconds=benchmark_config.duration,
         container_cnt=container_cfg.get_container_cnt_list(),
         nb_threads=threads,
-        execution_type=benchmark_config.exec_env,
+        execution_type=list(benchmark_config.exec_env.keys()),
         noise=benchmark_config.noise,
         initial_size=benchmark_config.initial_size,
         nb_runs=benchmark_config.repeat,

--- a/config/bm-external/bwrap/baseline.json
+++ b/config/bm-external/bwrap/baseline.json
@@ -22,9 +22,9 @@
     }
   ],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ],
+    "exec_env": {
+      "native": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/bwrap/filesystem.json
+++ b/config/bm-external/bwrap/filesystem.json
@@ -22,9 +22,9 @@
     }
   ],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ],
+    "exec_env": {
+      "native": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/bwrap/max-isolation.json
+++ b/config/bm-external/bwrap/max-isolation.json
@@ -22,9 +22,9 @@
     }
   ],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ],
+    "exec_env": {
+      "native": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/bwrap/namespaces.json
+++ b/config/bm-external/bwrap/namespaces.json
@@ -22,9 +22,9 @@
     }
   ],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ],
+    "exec_env": {
+      "native": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/cgroups/runc-strace.json
+++ b/config/bm-external/cgroups/runc-strace.json
@@ -1,9 +1,9 @@
 {
   "plots": [],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ]
+    "exec_env": {
+      "native": []
+    }
   },
   "containers": {
     "container_list": {

--- a/config/bm-external/cgroups/runc.json
+++ b/config/bm-external/cgroups/runc.json
@@ -137,9 +137,9 @@
     }
   ],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ],
+    "exec_env": {
+      "native": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/cgroups/youki-strace.json
+++ b/config/bm-external/cgroups/youki-strace.json
@@ -1,9 +1,9 @@
 {
   "plots": [],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ]
+    "exec_env": {
+      "native": []
+    }
   },
   "containers": {
     "container_list": {

--- a/config/bm-external/cgroups/youki.json
+++ b/config/bm-external/cgroups/youki.json
@@ -137,9 +137,9 @@
     }
   ],
   "benchmark_config": {
-    "exec_env": [
-      "native"
-    ],
+    "exec_env": {
+      "native": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/fio.json
+++ b/config/bm-external/fio.json
@@ -15,9 +15,9 @@
     "initial_size": [
       1
     ],
-    "exec_env": [
-      "container"
-    ],
+    "exec_env": {
+      "container": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm-external/stress-ng.json
+++ b/config/bm-external/stress-ng.json
@@ -23,9 +23,9 @@
   ],
   "benchmark_config": {
     "duration": 3,
-    "exec_env": [
-      "container"
-    ],
+    "exec_env": {
+      "container": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -45,9 +45,11 @@
     },
     "duration": 1,
     "exec_env": {
-      "bwrap":["--die-with-parent"],
-      "native":[],
-      "container":[]
+      "bwrap": [
+        "--die-with-parent"
+      ],
+      "native": [],
+      "container": []
     }
   },
   "containers": {

--- a/config/bm_empty.json
+++ b/config/bm_empty.json
@@ -44,11 +44,11 @@
       ]
     },
     "duration": 1,
-    "exec_env": [
-      "bwrap",
-      "native",
-      "container"
-    ]
+    "exec_env": {
+      "bwrap":["--die-with-parent"],
+      "native":[],
+      "container":[]
+    }
   },
   "containers": {
     "core_assignment_policy": {

--- a/config/org-apps/rocksdb-flamegraph.json
+++ b/config/org-apps/rocksdb-flamegraph.json
@@ -13,9 +13,9 @@
   ],
   "benchmark_config": {
     "duration": 30,
-    "exec_env": [
-      "container"
-    ],
+    "exec_env": {
+      "container": []
+    },
     "monitors": {
       "mpstat": [
         "-n",

--- a/config/org-apps/rocksdb-strace.json
+++ b/config/org-apps/rocksdb-strace.json
@@ -13,9 +13,9 @@
   ],
   "benchmark_config": {
     "duration": 1,
-    "exec_env": [
-      "container"
-    ],
+    "exec_env": {
+      "container": []
+    },
     "threads": {
       "values": [
         [

--- a/doc/bm-config.md
+++ b/doc/bm-config.md
@@ -18,7 +18,7 @@ General configuration for benchmarks, as well as a collection of system-level me
 |repeat|int|:white_check_mark:|`1`|    Number of times the benchmark should be repeated.     JSON example: `"repeat": 1` |
 |initial_size|list[int]|:white_check_mark:|`[0]`|    The initial size parameter that should be passed     to the benchmark initialization.     JSON example: `"initial_size" : [1, 1000]` |
 |noise|list[int]|:white_check_mark:|`[0]`|    How many `nop` operations to run between real     operations.     JSON example: `"noise" : [0, 1000]` |
-|exec_env|list[[ExecutionType](#executiontype)]|:white_check_mark:|`["native", "container"]`|    Whether to execute the benchmark in a container or     natively. JSON example: `"exec_env" : ["container", "native"]` |
+|exec_env|dict[[ExecutionType](#executiontype), list[str]]|:white_check_mark:|`{"native":[], "container":[]}`|    Dictates in which environments the benchmark is executed, and which     extra arguments are used. Note that currently the arguments are     only considered in case of `bwrap`.     JSON example: `"exec_env" : {"native":[], "container":[], "bwrap":["--die-with-parent"]}` |
 |monitors|dict[[MonitorType](#monitortype), list[str]]|:white_check_mark:|`{}`|    Monitors to run in the background. |
 |threads|[ListConfig](#listconfig)|:white_check_mark:|`{"values": [[1]]}`|    Determines number of threads to run target benchmarks with.     If not provided all applications will be run with 1 thread. |
 


### PR DESCRIPTION
Change

- change type of `exec_env`  from `list` to `dict`. Allow passing args list for execution env.
- reflect the change on the affected config and documentation.
- extend args of  `bwrap` with the given config.