### PR TITLE
[bm-runner] Refactor `Process` execution env to use `BackgroundProcess`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ Testing/
 gen-ws
 bm-external/byte-unixbench
 bm-external/sysbench
+bm-external/will-it-scale
 bm-external/cgroups/rootfs/
 bm-external/cgroups/config.json

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -105,4 +105,4 @@ class Bubblewrap(ExecutionUnit):
 
     def stop(self):
         if self.process is not None:
-            self.process.force_stop()
+            self.process.stop()

--- a/bm-runner/bm_bwrap.py
+++ b/bm-runner/bm_bwrap.py
@@ -105,4 +105,4 @@ class Bubblewrap(ExecutionUnit):
 
     def stop(self):
         if self.process is not None:
-            self.process.stop()
+            self.process.force_stop()

--- a/bm-runner/bm_executer.py
+++ b/bm-runner/bm_executer.py
@@ -14,7 +14,7 @@ from monitors.monitor_factory import MonitorFactory
 from utils.logger import bm_log, LogType
 from bm_utils import resolve_path
 from config.container import ContainersConfig
-from bm_process import Process
+from bm_native import Native
 from bm_container import Container
 from bm_bwrap import Bubblewrap
 from bm_exec_unit import ExecutionUnit, ExecutionType
@@ -92,7 +92,7 @@ class Executer:
                     nic=self.nics.get_cfg(idx) if self.nics else None,
                 )
             case ExecutionType.NATIVE:
-                return Process(
+                return Native(
                     idx=idx,
                     home_dir=self.home_dir,
                     core_set=core_set,

--- a/bm-runner/bm_native.py
+++ b/bm-runner/bm_native.py
@@ -11,7 +11,7 @@ from utils.process import BackgroundProcess
 from pathlib import Path
 
 
-class Process(ExecutionUnit):
+class Native(ExecutionUnit):
 
     def __init__(self, idx, home_dir, record_data_dir, core_set, app: Application):
         super().__init__(idx=idx, home_dir=home_dir, app=app, type=ExecutionType.NATIVE)
@@ -53,7 +53,7 @@ class Process(ExecutionUnit):
             returncode = self.process.wait_indefinitely()
             if returncode != 0:
                 bm_log(
-                    f"bwrap process {self.name} failed/crashed with return code {returncode}",
+                    f"Native process {self.name} failed/crashed with return code {returncode}",
                     LogType.FATAL,
                 )
                 sys.exit(1)

--- a/bm-runner/bm_native.py
+++ b/bm-runner/bm_native.py
@@ -59,4 +59,4 @@ class Native(ExecutionUnit):
 
     def stop(self):
         if self.process:
-            self.process.stop()
+            self.process.force_stop()

--- a/bm-runner/bm_native.py
+++ b/bm-runner/bm_native.py
@@ -27,12 +27,11 @@ class Native(ExecutionUnit):
         if self.app.cd:
             assert self.app.path is not None, "path is not set while change directory is requested!"
             change_dir = f" cd {self.app.path} && "
-        inner_cmd = f"{change_dir} {command}"
+        inner_cmd = f"{self.CMD_WHILE_NOT_START} {change_dir} {command}"
 
         cmds = [
             "/bin/bash",
             "-c",
-            self.CMD_WHILE_NOT_START,
             inner_cmd,
         ]
 

--- a/bm-runner/bm_native.py
+++ b/bm-runner/bm_native.py
@@ -59,4 +59,4 @@ class Native(ExecutionUnit):
 
     def stop(self):
         if self.process:
-            self.process.force_stop()
+            self.process.stop()

--- a/bm-runner/bm_process.py
+++ b/bm-runner/bm_process.py
@@ -1,22 +1,14 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-import os
-import resource
 import sys
-import subprocess
 from bm_exec_unit import ExecutionUnit
-from bm_utils import stop_process
 from bm_config import Application
 from config.benchmark import ExecutionType
 from utils.logger import bm_log, LogType
 from bm_utils import resolve_path
-
-
-def preexec_process():
-    os.setpgrp()
-    (fd_soft, fd_hard) = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (fd_hard, fd_hard))
+from utils.process import BackgroundProcess
+from pathlib import Path
 
 
 class Process(ExecutionUnit):
@@ -35,33 +27,37 @@ class Process(ExecutionUnit):
         if self.app.cd:
             assert self.app.path is not None, "path is not set while change directory is requested!"
             change_dir = f" cd {self.app.path} && "
-        commands = (
-            f"{self.CMD_WHILE_NOT_START}{change_dir}taskset --cpu-list {self.core_set} {command}"
+        inner_cmd = f"{change_dir} {command}"
+
+        cmds = [
+            "/bin/bash",
+            "-c",
+            self.CMD_WHILE_NOT_START,
+            inner_cmd,
+        ]
+
+        self.process = BackgroundProcess(
+            name=self.name,
+            cmds=cmds,
+            out_dir=str(resolve_path(Path(self.output_file).parent)),
+            efile_name=Path(self.err_file).name,
+            ofile_name=Path(self.output_file).name,
+            wdir=self.home_dir,
+            pin=self.core_set,
         )
-        with open(resolve_path(self.err_file), "w") as err_file:
-            with open(resolve_path(self.output_file), "w") as outfile:
-                self.process = subprocess.Popen(
-                    commands,
-                    shell=True,
-                    stdout=outfile,
-                    stderr=err_file,
-                    preexec_fn=preexec_process,
-                    cwd=self.home_dir,
-                )
-        bm_log(f"launched process {self.name} with {commands}")
+        self.process.start()
         return True
 
     def wait(self):
-        if self.process is None:
-            return
-        self.process.wait()
-        if self.process.returncode != 0:
-            bm_log(
-                f"process {self.name} has failed/or crashed with return code {self.process.returncode}",
-                LogType.FATAL,
-            )
-            sys.exit(1)
+        if self.process:
+            returncode = self.process.wait_indefinitely()
+            if returncode != 0:
+                bm_log(
+                    f"bwrap process {self.name} failed/crashed with return code {returncode}",
+                    LogType.FATAL,
+                )
+                sys.exit(1)
 
     def stop(self):
-        if self.process is not None:
-            stop_process(self.process.pid)
+        if self.process:
+            self.process.force_stop()

--- a/bm-runner/tests/test_with_plugins.py
+++ b/bm-runner/tests/test_with_plugins.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from bm_utils import ensure_exists
 from bm_container import Container
-from bm_process import Process
+from bm_native import Native
 from config.application import Application
 
 
@@ -31,7 +31,7 @@ def get_command(
     app = Application("ls", args=args)
 
     if is_process:
-        eu = Process(
+        eu = Native(
             app=app,
             idx=0,
             record_data_dir=results_dir,

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -102,6 +102,7 @@ class BackgroundProcess:
             self.cmds,
             stdout=self.ofile,
             stderr=self.efile,
+            env=env,
             preexec_fn=self.__preexec_fn,
             cwd=self.wdir,
         )

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -150,16 +150,7 @@ class BackgroundProcess:
         bm_log(
             f"Waiting for {self.name} without timeout, with PID = {self.process.pid} to terminate"
         )
-        ret = self.process.wait()
-        if ret != 0:
-            bm_log(
-                f"""
-                    ERROR:
-                   -----
-                   {self.read_err()}
-                   """
-            )
-        return ret
+        return self.process.wait()
 
     def stop(self, timeout=TIMEOUT_SEC) -> int:
         """
@@ -188,17 +179,6 @@ class BackgroundProcess:
         """
         try:
             with open(self.ofile_name, "r") as file:
-                return file.read()
-        except Exception as e:
-            bm_log(f"Failed to read {self.ofile_name} {e}", LogType.ERROR)
-            return ""
-
-    def read_err(self):
-        """
-        Returns the content of the `stdout` file.
-        """
-        try:
-            with open(self.efile_name, "r") as file:
                 return file.read()
         except Exception as e:
             bm_log(f"Failed to read {self.ofile_name} {e}", LogType.ERROR)

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -126,9 +126,10 @@ class BackgroundProcess:
         """
         Kills the process and whatever children the process spawned.
         """
-        if self.process and self.process.poll() is None:
-            bm_log(f"Killing {self.name}, with PID = {self.process.pid}")
-            stop_process(self.process.pid)
+        if self.process:
+            if self.process.poll() is None:
+                bm_log(f"Killing {self.name}, with PID = {self.process.pid}")
+                stop_process(self.process.pid)
             self.__close_file(self.ofile)
             self.__close_file(self.efile)
 

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -96,11 +96,12 @@ class BackgroundProcess:
         assert self.process is None, "it seems, it has already been started!"
         self.ofile = open(self.ofile_name, "w")
         self.efile = open(self.efile_name, "w")
+        env = os.environ.copy()
+        env.update(self.Env)
         self.process = subprocess.Popen(
             self.cmds,
             stdout=self.ofile,
             stderr=self.efile,
-            env=self.Env,
             preexec_fn=self.__preexec_fn,
             cwd=self.wdir,
         )
@@ -149,7 +150,16 @@ class BackgroundProcess:
         bm_log(
             f"Waiting for {self.name} without timeout, with PID = {self.process.pid} to terminate"
         )
-        return self.process.wait()
+        ret = self.process.wait()
+        if ret != 0:
+            bm_log(
+                f"""
+                    ERROR:
+                   -----
+                   {self.read_err()}
+                   """
+            )
+        return ret
 
     def stop(self, timeout=TIMEOUT_SEC) -> int:
         """
@@ -178,6 +188,17 @@ class BackgroundProcess:
         """
         try:
             with open(self.ofile_name, "r") as file:
+                return file.read()
+        except Exception as e:
+            bm_log(f"Failed to read {self.ofile_name} {e}", LogType.ERROR)
+            return ""
+
+    def read_err(self):
+        """
+        Returns the content of the `stdout` file.
+        """
+        try:
+            with open(self.efile_name, "r") as file:
                 return file.read()
         except Exception as e:
             bm_log(f"Failed to read {self.ofile_name} {e}", LogType.ERROR)

--- a/bm-runner/utils/process.py
+++ b/bm-runner/utils/process.py
@@ -129,6 +129,8 @@ class BackgroundProcess:
         if self.process and self.process.poll() is None:
             bm_log(f"Killing {self.name}, with PID = {self.process.pid}")
             stop_process(self.process.pid)
+            self.__close_file(self.ofile)
+            self.__close_file(self.efile)
 
     def is_alive(self) -> bool:
         """

--- a/doc/development.md
+++ b/doc/development.md
@@ -11,7 +11,7 @@ The main runner implementation lives in `bm-runner/`. The runner entry point is
 `bm-runner/main.py`; configuration parsing is in `bm-runner/bm_config.py` and
 `bm-runner/config/`; benchmark orchestration is in `bm-runner/benchmark.py` and
 `bm-runner/bm_executer.py`; native and container execution live in
-`bm-runner/bm_process.py` and `bm-runner/bm_container.py`; monitors live under
+`bm-runner/bm_native.py` and `bm-runner/bm_container.py`; monitors live under
 `bm-runner/monitors/`; plotting is implemented in `bm-runner/bm_visualize.py`.
 
 Builtin benchmark targets live under `bench/targets/` and external benchmark
@@ -90,7 +90,7 @@ report the missing requirement rather than changing code to hide the failure.
 
 - New runner config field: update the matching class and Docstrings under
   `bm-runner/config/`, parsing/defaults, and tests under `bm-runner/tests/`.
-- Run the following script to update doc/bm-config.md `helpers/update-doc.sh` 
+- Run the following script to update doc/bm-config.md `helpers/update-doc.sh`
 - New monitor: implement the monitor under `bm-runner/monitors/`, wire the
   monitor type and factory, document the config in `doc/bm-config.md`, and test
   empty/failing output handling.


### PR DESCRIPTION
Change

- refactor `Process` to use `BackgroundProcess` class
  and reuse existing functionality.
- rename `bm_process.py`  to `bm_native.py`
- rename `Process` class to `Native`

Fix

- do not overwrite env in `BackgroundProcess`
  append to it instead.
- close files in `force_stop`
