### PR TITLE
[bm-runner] Include relevant information in the benchmark name.

### DIFF
--- a/bm-runner/main.py
+++ b/bm-runner/main.py
@@ -38,11 +38,11 @@ def csbCampaign(
     pretty: Optional[Dict[str, str]] = None,
 ) -> CampaignCartesianProduct:
     variables = {
+        "execution_type": execution_type,
+        "container_cnt": container_cnt,
         "nb_threads": nb_threads,
         "noise": noise,
         "initial_size": initial_size,
-        "container_cnt": container_cnt,
-        "execution_type": execution_type,
     }
 
     pretty_dict = None

--- a/bm-runner/main.py
+++ b/bm-runner/main.py
@@ -79,11 +79,13 @@ def construct_bm_name(config_file: Path):
     # remove everything before and including config
     if "config" in parts:
         parts = parts[parts.index("config") + 1 :]
-    # if external is in the path remove it as well
-    if parts and parts[0] == "bm-external":
-        parts = parts[1:]
-    # now join with `_`
-    return "_".join(parts)
+        # if external is in the path remove it as well
+        if parts and parts[0] == "bm-external":
+            parts = parts[1:]
+        # now join with `_`
+        return "_".join(parts)
+    else:
+        return config_file.stem
 
 
 ###########################################################################

--- a/bm-runner/main.py
+++ b/bm-runner/main.py
@@ -69,6 +69,23 @@ def csbCampaign(
     )
 
 
+def construct_bm_name(config_file: Path):
+    """
+    Constructs the benchmark name based on the given
+    configuration file name.
+    """
+    # return parts without ext
+    parts = list(config_file.with_suffix("").parts)
+    # remove everything before and including config
+    if "config" in parts:
+        parts = parts[parts.index("config") + 1 :]
+    # if external is in the path remove it as well
+    if parts and parts[0] == "bm-external":
+        parts = parts[1:]
+    # now join with `_`
+    return "_".join(parts)
+
+
 ###########################################################################
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Container Scalability Benchmark")
@@ -111,8 +128,7 @@ if __name__ == "__main__":
         traceback.print_exc()
         sys.exit(1)
 
-    # get json file name without extension and path
-    benchmark_name = Path(arg_config).stem
+    benchmark_name = construct_bm_name(Path(arg_config))
 
     # Campaign Parameters
     assert bm_config.g_config is not None


### PR DESCRIPTION
Change

- change the order of the results subfolders
- use relevant parts of the config path in the benchmark name