### PR TITLE
[bm-runner] Sort plots in the final report.

### DIFF
--- a/bm-runner/analyze.py
+++ b/bm-runner/analyze.py
@@ -269,6 +269,6 @@ if __name__ == "__main__":
     write_to_file(dir=output_dir_name, fname="results.csv", content=csv)
 
     report = Report("Analysis Report")
-    dump_graphs_to_doc(output_dir_name, report, split=3)
+    dump_graphs_to_doc(output_dir_name, report)
     report.save(os.path.join(output_dir_name, "results.html"))
     bm_log(f"Results written to {output_dir_name}", LogType.INFO)

--- a/bm-runner/bm_utils.py
+++ b/bm-runner/bm_utils.py
@@ -34,6 +34,14 @@ def resolve_path(path: PathType, use_in_container: bool = False) -> PathType:
     return new_path
 
 
+def get_path_rel_to_csb(path: str) -> str:
+    try:
+        rel = Path(path).relative_to(Path(os.getcwd()).parent)
+        return str(rel)
+    except Exception:
+        return path
+
+
 def check_data_directory(output_dir):
     if output_dir is None:
         bm_log(

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -229,7 +229,7 @@ def dump_plots_with_ext(dir: str, report: Report, ext: str = "png", max_plots_pe
     report.embed_plots(plots_table)
 
 
-def dump_graphs_to_doc(dir, report: Report, split=4):
+def dump_graphs_to_doc(dir, report: Report):
     dump_plots_with_ext(dir, report, ext="png", max_plots_per_row=2)
     dump_plots_with_ext(dir, report, ext="svg", max_plots_per_row=1)
 

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -209,7 +209,9 @@ def dump_graphs_to_doc(dir, report: Report, split=4):
     plots.sort(key=plot_sort_key)
     plots = [plots[i : i + split] for i in range(0, len(plots), split)]
     report.embed_plots(plots)
-    report.embed_plots([svg])
+
+    svg =  [svg[i : i + 1] for i in range(0, len(svg), 1)]
+    report.embed_plots(svg)
 
 
 ###########################################################################

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -194,6 +194,7 @@ def container_folder(p: Path):
             return parent.name
     return ""  # fallback if not found
 
+
 def plot_sort_key(path):
     p = Path(path)
     return (p.stem, container_folder(p))

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -192,27 +192,46 @@ def container_folder(p: Path):
     for parent in p.parents:
         if "container_cnt" in parent.name:
             return parent.name
-    return ""  # fallback if not found
+    return "z"  # fallback if not found
 
 
 def plot_sort_key(path):
     p = Path(path)
-    return (p.stem, container_folder(p))
 
+    return (p.stem, p.stat().st_mtime, container_folder(p))
+
+
+def split_plots(plots, split):
+    groups = []
+    current = []
+    current_stem = None
+
+    for plot in plots:
+        stem = Path(plot).stem
+
+        if current and (stem != current_stem or len(current) >= split):
+            groups.append(current)
+            current = []
+
+        current.append(plot)
+        current_stem = stem
+
+    if current:
+        groups.append(current)
+
+    return groups
+
+
+def dump_plots_with_ext(dir:str, report: Report, ext:str="png", max_plots_per_row=1):
+    dir = os.path.realpath(dir)
+    plots = glob.glob(os.path.join(dir, "**", f"*.{ext}"), recursive=True)
+    plots.sort(key=plot_sort_key)
+    plots_table = split_plots(plots, max_plots_per_row)
+    report.embed_plots(plots_table)
 
 def dump_graphs_to_doc(dir, report: Report, split=4):
-    # find all generated plots and embed them into the HTML document
-    dir = os.path.realpath(dir)
-    png = glob.glob(os.path.join(dir, "**", "*.png"), recursive=True)
-    svg = glob.glob(os.path.join(dir, "**", "*.svg"), recursive=True)
-    plots = png
-    plots.sort(key=plot_sort_key)
-    plots = [plots[i : i + split] for i in range(0, len(plots), split)]
-    report.embed_plots(plots)
-
-    svg =  [svg[i : i + 1] for i in range(0, len(svg), 1)]
-    report.embed_plots(svg)
-
+    dump_plots_with_ext(dir, report, ext="png", max_plots_per_row=2)
+    dump_plots_with_ext(dir, report, ext="svg", max_plots_per_row=1)
 
 ###########################################################################
 def split_data_frame(df: DataFrame) -> dict:

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -188,15 +188,27 @@ def create_plots(df, plots: list[PlotConfig], dir, info: str):
 
 
 ###########################################################################
-def dump_graphs_to_doc(dir, report: Report, split=1):
+def container_folder(p: Path):
+    for parent in p.parents:
+        if "container_cnt" in parent.name:
+            return parent.name
+    return ""  # fallback if not found
+
+def plot_sort_key(path):
+    p = Path(path)
+    return (p.stem, container_folder(p))
+
+
+def dump_graphs_to_doc(dir, report: Report, split=4):
     # find all generated plots and embed them into the HTML document
     dir = os.path.realpath(dir)
     png = glob.glob(os.path.join(dir, "**", "*.png"), recursive=True)
     svg = glob.glob(os.path.join(dir, "**", "*.svg"), recursive=True)
-    plots = png + svg
-    plots.sort()
+    plots = png
+    plots.sort(key=plot_sort_key)
     plots = [plots[i : i + split] for i in range(0, len(plots), split)]
     report.embed_plots(plots)
+    report.embed_plots([svg])
 
 
 ###########################################################################

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -187,22 +187,21 @@ def create_plots(df, plots: list[PlotConfig], dir, info: str):
             )
 
 
-###########################################################################
-def container_folder(p: Path):
-    for parent in p.parents:
-        if "container_cnt" in parent.name:
-            return parent.name
-    return "z"  # fallback if not found
-
-
 def plot_sort_key(path):
+    """
+    Sorts according to filename, and creation date.
+    """
     p = Path(path)
+    return (p.stem, p.stat().st_mtime)
 
-    return (p.stem, p.stat().st_mtime, container_folder(p))
 
-
-def split_plots(plots, split):
-    groups = []
+def split_in_lists(plots: list[str], split: int) -> list[list]:
+    """
+    Splits the given list into list of lists
+    the split happens when either a new file name is encountered,
+    or if the current length is greater than split.
+    """
+    lists = []
     current = []
     current_stem = None
 
@@ -210,28 +209,30 @@ def split_plots(plots, split):
         stem = Path(plot).stem
 
         if current and (stem != current_stem or len(current) >= split):
-            groups.append(current)
+            lists.append(current)
             current = []
 
         current.append(plot)
         current_stem = stem
 
     if current:
-        groups.append(current)
+        lists.append(current)
 
-    return groups
+    return lists
 
 
-def dump_plots_with_ext(dir:str, report: Report, ext:str="png", max_plots_per_row=1):
+def dump_plots_with_ext(dir: str, report: Report, ext: str = "png", max_plots_per_row=1):
     dir = os.path.realpath(dir)
     plots = glob.glob(os.path.join(dir, "**", f"*.{ext}"), recursive=True)
     plots.sort(key=plot_sort_key)
-    plots_table = split_plots(plots, max_plots_per_row)
+    plots_table = split_in_lists(plots, max_plots_per_row)
     report.embed_plots(plots_table)
+
 
 def dump_graphs_to_doc(dir, report: Report, split=4):
     dump_plots_with_ext(dir, report, ext="png", max_plots_per_row=2)
     dump_plots_with_ext(dir, report, ext="svg", max_plots_per_row=1)
+
 
 ###########################################################################
 def split_data_frame(df: DataFrame) -> dict:

--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -15,7 +15,6 @@ from config.env_config import UniversalConfig, EnvUniversalConfig
 import math
 import seaborn as sns
 import matplotlib.pyplot as plt
-import time
 
 
 class BpfTrace(Monitor):
@@ -422,7 +421,7 @@ class BpfTrace(Monitor):
                 ylabel="Buckets",
             )
 
-        figure_name = f"{output_dir}/{plot.title}_{time.perf_counter()}"
+        figure_name = f"{output_dir}/{plot.title}"
         fig.tight_layout()
         fig.savefig(f"{figure_name}.png", dpi=300, bbox_inches="tight")
         plt.close(fig)

--- a/bm-runner/visual/plotchart.py
+++ b/bm-runner/visual/plotchart.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas import DataFrame
 from utils.logger import LogType, bm_log
 import seaborn as sns
-import time
 
 
 class PlotChart:
@@ -95,7 +94,7 @@ class PlotChart:
         self.fig.set_size_inches(w=10, h=8)
         self.fig.tight_layout()
 
-        figure_name = f"{out_fig_name}_{time.perf_counter()}"
+        figure_name = f"{out_fig_name}"
         self.fig.savefig(f"{figure_name}.png", transparent=False)
         if gen_pdf:
             self.fig.savefig(f"{figure_name}.pdf", transparent=False)

--- a/bm-runner/visual/plotchart.py
+++ b/bm-runner/visual/plotchart.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pandas import DataFrame
 from utils.logger import LogType, bm_log
 import seaborn as sns
+from pathlib import Path
 
 
 class PlotChart:
@@ -94,13 +95,15 @@ class PlotChart:
         self.fig.set_size_inches(w=10, h=8)
         self.fig.tight_layout()
 
-        figure_name = f"{out_fig_name}"
-        self.fig.savefig(f"{figure_name}.png", transparent=False)
+        fig_name = f"{out_fig_name}.png"
+        if Path(fig_name).exists():
+            bm_log(f"{fig_name} already exists and is going to be overwritten!!!", LogType.WARNING)
+        self.fig.savefig(fig_name, transparent=False)
         if gen_pdf:
-            self.fig.savefig(f"{figure_name}.pdf", transparent=False)
+            self.fig.savefig(f"{out_fig_name}.pdf", transparent=False)
         plt.close()
 
-        return f"{figure_name}.png"
+        return fig_name
 
     @staticmethod
     def __col_exists(df: DataFrame, col: str, title: str) -> bool:

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -7,6 +7,8 @@ import datetime
 import base64
 import re
 from benchkit.benchmark import PathType
+from pathlib import Path
+import os
 
 
 class Report:
@@ -101,7 +103,8 @@ class Report:
                 cell = div()
                 cell.add(a(img_div, href=plot_path))
                 if show_path:
-                   cell.add(a(plot_path, href=plot_path))
+                    relative_path = Path(plot_path).relative_to(Path(os.getcwd()).parent)
+                    cell.add(a(str(relative_path), href=str(relative_path)))
                 row.add(td(cell, width=f"{width}%"))
         # append the plots/graphs table to the given document
         self.doc.add(tbl)

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -82,6 +82,8 @@ class Report:
         plot_lists : list[list[str]]
             a list of lists. Each list is added to the table as a row, and each element is a cell.
         """
+        if len(plot_lists) == 0:
+            return
         tbl = table()
         num_cols = max(map(len, plot_lists))
         width = 100 / num_cols

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -7,8 +7,7 @@ import datetime
 import base64
 import re
 from benchkit.benchmark import PathType
-from pathlib import Path
-import os
+from bm_utils import get_path_rel_to_csb
 
 
 class Report:
@@ -89,7 +88,6 @@ class Report:
         for list in plot_lists:
             row = tr()
             tbl.add(row)
-            print(f"{len(list)} {width}")
             for plot_path in list:
                 if not plot_path:
                     row.add(td("", width=f"{width}%"))
@@ -101,10 +99,10 @@ class Report:
                     else self.embed_img(plot_path)
                 )
                 cell = div()
-                cell.add(a(img_div, href=plot_path))
+                url = get_path_rel_to_csb(plot_path)
+                cell.add(a(img_div, href=url))
                 if show_path:
-                    relative_path = Path(plot_path).relative_to(Path(os.getcwd()).parent)
-                    cell.add(a(str(relative_path), href=str(relative_path)))
+                    cell.add(a(str(url), href=str(url)))
                 row.add(td(cell, width=f"{width}%"))
         # append the plots/graphs table to the given document
         self.doc.add(tbl)

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -101,10 +101,10 @@ class Report:
                     else self.embed_img(plot_path)
                 )
                 cell = div()
-                url = get_path_rel_to_csb(plot_path)
-                cell.add(a(img_div, href=url))
+                cell.add(a(img_div, href=plot_path))
                 if show_path:
-                    cell.add(a(str(url), href=str(url)))
+                    relative_path = get_path_rel_to_csb(plot_path)
+                    cell.add(a(relative_path, href=str(plot_path)))
                 row.add(td(cell, width=f"{width}%"))
         # append the plots/graphs table to the given document
         self.doc.add(tbl)

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -33,10 +33,15 @@ class Report:
             text-align: center;
             font-color: blue;
         }
-        .png_title {
-            font-size: 14px;
-            font-style: italic;
+        a, img {
+            width: 100%;
         }
+        a {
+            white-space: normal;
+            overflow-wrap: break-word;
+            word-break: break-word;
+        }
+
     """
 
     def __init__(self, title: str, add_title_date: bool = True, css_style=CSS_STYLE):
@@ -71,12 +76,14 @@ class Report:
 
     def embed_plots(self, plot_lists: list[list[str]], show_path: bool = True):
         tbl = table()
+        cols = len(plot_lists)
+        width = 100 / cols
         for list in plot_lists:
             row = tr()
             tbl.add(row)
             for plot_path in list:
                 if not plot_path:
-                    row.add(td(""))
+                    row.add(td("", width=f"{width}%"))
                     continue
 
                 img_div = (
@@ -87,8 +94,8 @@ class Report:
                 cell = div()
                 cell.add(a(img_div, href=plot_path))
                 if show_path:
-                    cell.add(a(plot_path, href=plot_path, _class="png_title"))
-                row.add(td(cell))
+                    cell.add(a(plot_path, href=plot_path))
+                row.add(td(cell, width=f"{width}%"))
         # append the plots/graphs table to the given document
         self.doc.add(tbl)
 
@@ -100,10 +107,10 @@ class Report:
             f.write(self.doc.render())
 
     @staticmethod
-    def embed_img(path: PathType) -> div:
+    def embed_img(path: PathType) -> img:
         data_uri = base64.b64encode(open(path, "rb").read()).decode("utf-8")
         img_tag = f"data:image/png;base64,{data_uri}"
-        return div(img(src=img_tag))
+        return img(src=img_tag)
 
     @staticmethod
     def embed_svg(path: PathType) -> div:

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -75,12 +75,19 @@ class Report:
         self.doc.add(tbl)
 
     def embed_plots(self, plot_lists: list[list[str]], show_path: bool = True):
+        """
+        Parameters
+        ---
+        plot_lists : list[list[str]]
+            a list of lists. Each list is added to the table as a row, and each element is a cell.
+        """
         tbl = table()
-        cols = len(plot_lists)
-        width = 100 / cols
+        num_cols = max(map(len, plot_lists))
+        width = 100 / num_cols
         for list in plot_lists:
             row = tr()
             tbl.add(row)
+            print(f"{len(list)} {width}")
             for plot_path in list:
                 if not plot_path:
                     row.add(td("", width=f"{width}%"))
@@ -94,7 +101,7 @@ class Report:
                 cell = div()
                 cell.add(a(img_div, href=plot_path))
                 if show_path:
-                    cell.add(a(plot_path, href=plot_path))
+                   cell.add(a(plot_path, href=plot_path))
                 row.add(td(cell, width=f"{width}%"))
         # append the plots/graphs table to the given document
         self.doc.add(tbl)


### PR DESCRIPTION
Change

- add plots to the report ordered by name and creation date. 
   This allows the user to compare graphs of the same type for different
   number of execution units quicker, as they are listed after each other
   and less scrolling is needed.
- add flamegraphs after each other sorted by creation date.

Fix

- let width be relative to number of cells in `embed_plots`

