### PR TITLE
[bm-runner] Fix relative path and duplicate plot names.

### DIFF
--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -335,8 +335,9 @@ def visualize_in_html(output_dir: Path, title: str, plots: list[PlotConfig]):
     for key, df in data_frames.items():
         add_info_tbl(df, report, result_file)
         create_plots(df, plots, output_dir, info=key)
-        # dump graphs to HTML document
-        dump_graphs_to_doc(output_dir, report)
+
+    # dump all plot to the HTML report
+    dump_graphs_to_doc(output_dir, report)
     report.save()
     bm_log(
         f"visualized results can be found in {output_file_name} with {title}",

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -156,7 +156,7 @@ def create_min_max_avg_plot(org_df, config: PlotConfig, dir: str) -> str:
 
 ###########################################################################
 def create_plot(df, plot: PlotConfig, dir, info: str) -> str:
-    plot.fname += f"_{info}"
+    plot.fname = f"{plot.fname}_{info}"
     match plot.type:
         case PlotType.NORMAL:
             fig_name = f"{dir}/{plot.fname}"

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -51,7 +51,7 @@ def create_success_rate_plot(org_df, config: PlotConfig, dir) -> str:
     )
     # overwrite
     config.y = succ_percent
-    return PlotChart.plot(plot=config, df=df, out_fig_name=f"{dir}/{prefix}_succ_percent")
+    return PlotChart.plot(plot=config, df=df, out_fig_name=f"{dir}/{prefix}{config.fname}")
 
 
 ###########################################################################
@@ -151,14 +151,15 @@ def create_min_max_avg_plot(org_df, config: PlotConfig, dir: str) -> str:
         errorbar=min_max_errorbar,
     )
 
-    return pc.save(out_fig_name=f"{dir}/{config.y}_min_avg_max")
+    return pc.save(out_fig_name=f"{dir}/{config.fname}")
 
 
 ###########################################################################
 def create_plot(df, plot: PlotConfig, dir, info: str) -> str:
+    plot.fname += f"_{info}"
     match plot.type:
         case PlotType.NORMAL:
-            fig_name = f"{dir}/{plot.x}_vs_{plot.y}_{info}"
+            fig_name = f"{dir}/{plot.fname}"
             return PlotChart.plot(plot=plot, df=df, out_fig_name=fig_name)
         case PlotType.MIN_MAX_AVG:
             return create_min_max_avg_plot(org_df=df, config=plot, dir=dir)
@@ -239,7 +240,7 @@ def split_data_frame(df: DataFrame) -> dict:
     frames = {}
     threads = df["nb_threads"].unique()
     for t in threads:
-        key = f"t={t}"
+        key = f"{t}_threads"
         frames[key] = df[df["nb_threads"] == t]
     return frames
 
@@ -248,7 +249,7 @@ def create_mean_plot(df: DataFrame, plot: PlotConfig, dir):
     return PlotChart.plot(
         plot=plot,
         df=df,
-        out_fig_name=f"{dir}/{plot.y}_mean",
+        out_fig_name=f"{dir}/{plot.fname}",
         add_points=True,
         estimator="mean",
     )
@@ -294,7 +295,7 @@ def create_linearity_plot(df: DataFrame, plot: PlotConfig, dir):
 
     plot.y = "linearity"
     plot.y_lbl = "Linearity"
-    return PlotChart.plot(plot=plot, df=lin_df, out_fig_name=f"{dir}/linearity")
+    return PlotChart.plot(plot=plot, df=lin_df, out_fig_name=f"{dir}/{plot.fname}")
 
 
 ###########################################################################

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -324,7 +324,8 @@ def visualize_in_html(output_dir: Path, title: str, plots: list[PlotConfig]):
     if data_frame is None:
         return
     hostname = data_frame["hostname"].unique()[0]
-    report = Report(title=f"{hostname}-{title}")
+    output_file_name = os.path.join(parentdir(output_dir), f"{output_dir}.html")
+    report = Report(title=f"{hostname}-{title}", fname=output_file_name)
     # we split the data-frame into multiple data frames to help with visualization
     data_frames = split_data_frame(data_frame)
     # For each data frame we'll generate the related graphs
@@ -334,9 +335,7 @@ def visualize_in_html(output_dir: Path, title: str, plots: list[PlotConfig]):
         create_plots(df, plots, output_dir, info=key)
         # dump graphs to HTML document
         dump_graphs_to_doc(output_dir, report)
-
-    output_file_name = os.path.join(parentdir(output_dir), f"{output_dir}.html")
-    report.save(output_file_name)
+    report.save()
     bm_log(
         f"visualized results can be found in {output_file_name} with {title}",
         LogType.INFO,

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -15,6 +15,7 @@ from visual.plotchart import PlotChart
 from monitors.bpftrace import BpfTrace
 from visual.report import Report
 from bm_utils import read_data_frame_from_csv
+import copy
 
 
 ###########################################################################
@@ -156,7 +157,8 @@ def create_min_max_avg_plot(org_df, config: PlotConfig, dir: str) -> str:
 
 ###########################################################################
 def create_plot(df, plot: PlotConfig, dir, info: str) -> str:
-    plot.fname = f"{plot.fname}_{info}"
+    plot = copy.deepcopy(plot)
+    plot.fname += f"_{info}"
     match plot.type:
         case PlotType.NORMAL:
             fig_name = f"{dir}/{plot.fname}"

--- a/bm-runner/config/plot.py
+++ b/bm-runner/config/plot.py
@@ -108,6 +108,15 @@ class PlotConfig(dict):
         self.type = type
         self.shape = shape if shape is not None else self.DEFAULT_PLOT[self.type]
         self.palette = palette
+        self._fname = f"{self.x}_vs_{self.y}_{PlotType(self.type).value}"
 
     def set_palette(self, palette: PlotPalette | str):
         self.palette = palette
+
+    @property
+    def fname(self):
+        return self._fname
+
+    @fname.setter
+    def fname(self, value):
+        self._fname = value

--- a/bm-runner/monitors/bpftrace.py
+++ b/bm-runner/monitors/bpftrace.py
@@ -421,7 +421,7 @@ class BpfTrace(Monitor):
                 ylabel="Buckets",
             )
 
-        figure_name = f"{output_dir}/{plot.title}"
+        figure_name = f"{output_dir}/{plot.fname}"
         fig.tight_layout()
         fig.savefig(f"{figure_name}.png", dpi=300, bbox_inches="tight")
         plt.close(fig)

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -7,7 +7,10 @@ import datetime
 import base64
 import re
 from benchkit.benchmark import PathType
-from bm_utils import get_path_rel_to_csb
+from typing import Optional
+from pathlib import Path
+from utils.logger import LogType, bm_log
+import sys
 
 
 class Report:
@@ -45,7 +48,13 @@ class Report:
 
     """
 
-    def __init__(self, title: str, add_title_date: bool = True, css_style=CSS_STYLE):
+    def __init__(
+        self,
+        title: str,
+        fname: Optional[PathType] = None,
+        add_title_date: bool = True,
+        css_style=CSS_STYLE,
+    ):
         self.doc = document(title=title)
         if add_title_date:
             self.doc.add(h1(f"Title: {title}"))
@@ -53,9 +62,22 @@ class Report:
                 h2(f"Datetime: {datetime.datetime.now().strftime('%d.%m.%Y %H:%M:%S.%f')}")
             )
         self.__add_css_style(css_style)
+        self.fname = fname
 
     def add_line(self, text):
         self.doc.add(br(text))
+
+    def __get_rel_path(self, path: PathType) -> PathType:
+        """
+        Returns relative path to the report's parent directory if possible,
+        otherwise returns the given path.
+        """
+        try:
+            if self.fname:
+                return Path(path).relative_to(Path(self.fname).parent)
+        except Exception:
+            pass
+        return path
 
     def add_chapter(self, name: str, level=1):
         match level:
@@ -101,10 +123,10 @@ class Report:
                     else self.embed_img(plot_path)
                 )
                 cell = div()
-                cell.add(a(img_div, href=plot_path))
+                relative_path = str(self.__get_rel_path(plot_path))
+                cell.add(a(img_div, href=relative_path))
                 if show_path:
-                    relative_path = get_path_rel_to_csb(plot_path)
-                    cell.add(a(relative_path, href=str(plot_path)))
+                    cell.add(a(relative_path, href=relative_path))
                 row.add(td(cell, width=f"{width}%"))
         # append the plots/graphs table to the given document
         self.doc.add(tbl)
@@ -112,8 +134,12 @@ class Report:
     def __add_css_style(self, css_style):
         self.doc.add(style(css_style))
 
-    def save(self, report_file_name: PathType):
-        with open(report_file_name, "w") as f:
+    def save(self, report_file_name: Optional[PathType] = None):
+        fname = self.fname if report_file_name is None else report_file_name
+        if fname is None:
+            bm_log("Cannot save report, filename is not set!", LogType.FATAL)
+            sys.exit(1)
+        with open(str(fname), "w") as f:
             f.write(self.doc.render())
 
     @staticmethod

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -11,6 +11,7 @@ from typing import Optional
 from pathlib import Path
 from utils.logger import LogType, bm_log
 import sys
+import os
 
 
 class Report:
@@ -72,11 +73,13 @@ class Report:
         Returns relative path to the report's parent directory if possible,
         otherwise returns the given path.
         """
-        try:
-            if self.fname:
-                return Path(path).relative_to(Path(self.fname).parent)
-        except Exception:
-            pass
+        if self.fname:
+            plot_path = Path(path).resolve()
+            report_dir = Path(self.fname).resolve().parent
+            try:
+                return plot_path.relative_to(report_dir)
+            except ValueError:
+                return Path(os.path.relpath(plot_path, report_dir))
         return path
 
     def add_chapter(self, name: str, level=1):


### PR DESCRIPTION
Fix

- use correct relative path in plots links in the final report
- use distinct names for plots when different values of threads
  are available. Avoid overwriting plots.

