### PR TITLE
bm-runner: avoid Docker for native-only runs

### DIFF
--- a/bm-runner/bm_config.py
+++ b/bm-runner/bm_config.py
@@ -10,7 +10,7 @@ from config.plugin import Plugin
 from config.plot import PlotConfig
 from config.container import ContainersConfig
 from config.application import Application
-from config.benchmark import BenchmarkConfig
+from config.benchmark import BenchmarkConfig, ExecutionType
 import shutil
 from config.nics import NicsConfig
 from utils.logger import bm_log, LogType
@@ -116,9 +116,12 @@ class CampaignConfig:
     def __parse_container_cfg(self) -> ContainersConfig:
         containers = self.config.get(ContainersConfig.CONFIG_KEY)
         if containers:
-            return ContainersConfig(**containers)
+            result = ContainersConfig(**containers)
         else:
-            return ContainersConfig()
+            result = ContainersConfig()
+        if ExecutionType.CONTAINER in self.bm_cfg.exec_env:
+            result.ensure_img_exists()
+        return result
 
     def get_container_config(self) -> ContainersConfig:
         return self.container_cfg

--- a/bm-runner/config/container.py
+++ b/bm-runner/config/container.py
@@ -13,8 +13,12 @@ from config.policy import CoreAssignPolicy, PackGroup
 
 
 class ContainersConfig(dict):
-    MIN_NUM_STEPS: int = 6  # default minimum number of steps to set default container_list
-    MAX_NUM_STEPS: int = 10  # default maximum number of steps to set default container_list
+    MIN_NUM_STEPS: int = (
+        6  # default minimum number of steps to set default container_list
+    )
+    MAX_NUM_STEPS: int = (
+        10  # default maximum number of steps to set default container_list
+    )
     CONFIG_KEY: str = "containers"
     DEFAULT_IMG: dict[OperatingSystem, str] = {
         OperatingSystem.openEuler: "hub.oepkgs.net/openeuler/openeuler",
@@ -80,7 +84,6 @@ class ContainersConfig(dict):
         self.__set_cpus_containers(
             core_affinity_offsets=core_affinity_offsets, container_list=container_list
         )
-        self.__ensure_img_exists()
 
     def __set_cpus_containers(self, core_affinity_offsets, container_list):
         """
@@ -163,7 +166,9 @@ class ContainersConfig(dict):
         # we start range from zero and use max + 1, so that the last value will max
         # Always add 1 and max_num_containers
         default_container_list = list(range(0, max + 1, step))
-        assert default_container_list[0] == 0, "unexpected, given the range starts with zero"
+        assert (
+            default_container_list[0] == 0
+        ), "unexpected, given the range starts with zero"
         # we remove zero from the list
         default_container_list.remove(0)
         # make sure first element of the list is one
@@ -202,14 +207,19 @@ class ContainersConfig(dict):
 
     def __pull_image(self):
         client = docker.from_env()
-        bm_log(f"Docker image {self.image} does not exist. Pulling it now...\n", LogType.INFO)
+        bm_log(
+            f"Docker image {self.image} does not exist. Pulling it now...\n",
+            LogType.INFO,
+        )
         try:
             client.images.pull(self.image)
         except Exception as e:
-            bm_log(f"Failed to pull image {self.image} with error {str(e)}", LogType.FATAL)
+            bm_log(
+                f"Failed to pull image {self.image} with error {str(e)}", LogType.FATAL
+            )
             sys.exit(1)
 
-    def __ensure_img_exists(self):
+    def ensure_img_exists(self):
         client = docker.from_env()
         try:
             client.images.get(self.image)

--- a/bm-runner/tests/test_container_config.py
+++ b/bm-runner/tests/test_container_config.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 from config.container import ContainersConfig, CoreAssignPolicy
+from bm_config import CampaignConfig
 from utils.logger import bm_log
 from itertools import product
 import pytest
+import json
 
 
 CASES = [
@@ -66,9 +68,13 @@ def test_gen_container_list_defaults():
     common_core_counts = [6, 8, 12, 16, 24, 32, 88, 96, 160, 192, 256, 320, 384, 512]
     for num_cores in common_core_counts:
         container_counts = gen_list(num_cores)
-        bm_log(f"num_cores={num_cores} ({len(container_counts)} tests): {container_counts}")
+        bm_log(
+            f"num_cores={num_cores} ({len(container_counts)} tests): {container_counts}"
+        )
         assert len(container_counts) >= min_steps, f"Failed for num_cores={num_cores}"
-        assert len(container_counts) <= max_steps + 2, f"Failed for num_cores={num_cores}"
+        assert (
+            len(container_counts) <= max_steps + 2
+        ), f"Failed for num_cores={num_cores}"
         assert (
             container_counts[0] == 1
         ), f"First element should be 1 for num_cores={num_cores}: {container_counts}"
@@ -87,6 +93,29 @@ def test_gen_container_list_defaults():
             assert (
                 container_counts[0] == 1
             ), f"First element should be 1 for num_cores={num_cores}, cores_per_container={cores_per_container}: {container_counts}"
-            assert len(container_counts) <= max_steps + 2, f"Failed for max_containers={num_cores}"
+            assert (
+                len(container_counts) <= max_steps + 2
+            ), f"Failed for max_containers={num_cores}"
 
     # There are edge cases that we don't have specific expectations for.
+
+
+@pytest.mark.parametrize(
+    "execution_type, expected_calls", [("native", 0), ("container", 1)]
+)
+def test_image_checked_only_for_container_execution(
+    mocker, tmp_path, execution_type, expected_calls
+):
+    ensure_image = mocker.patch("config.container.ContainersConfig.ensure_img_exists")
+    mocker.patch("bm_config.get_host_ip", return_value="127.0.0.1")
+    config = {
+        "benchmark_config": {"exec_env": {execution_type: []}},
+        "containers": {"container_list": {"values": [[1]]}},
+        "applications": [{"name": "bm_empty", "operations": [1024]}],
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(config))
+
+    CampaignConfig(str(path))
+
+    assert ensure_image.call_count == expected_calls


### PR DESCRIPTION
Delay Docker image validation until the campaign actually requests container execution. Native-only generated benchmarks can then run without Docker socket access.

Validation:
- PYTHONPATH=. pytest -q tests/test_container_config.py
- 33 tests passed
- native-only generated ARM64 aggregate executed successfully on node26

Signed-off-by: Martin Beck <martin.beck2@gmx.de>