### PR TITLE
[bm-generator] Fail fast on empty trace translation.

### DIFF
--- a/bm-generator/02_parse.sh
+++ b/bm-generator/02_parse.sh
@@ -2,6 +2,8 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+set -e
+
 # Check that exactly one argument is given
 if [ $# != 1 ]; then
   echo "Usage: $0 </path/to/strace/log/file>"
@@ -55,4 +57,8 @@ bin/syz-trace2syz -vv 0 -file "${TRACE_ABS}" --deserialize "${DIR_PROG_ABS}" --n
 
 cd "${DIR_CUR}"
 
+compgen -G "${DIR_PROG_ABS}/*.prog" >/dev/null || {
+  echo "Trace translation produced no syzlang programs." >&2
+  exit 1
+}
 ./helper/compare_strace_to_syzprog.sh "${TRACE_ABS}" "${DIR_PROG_ABS}"

--- a/bm-generator/04_prepare.sh
+++ b/bm-generator/04_prepare.sh
@@ -23,4 +23,4 @@ fi
 
 mkdir -p "${DIR_TARGETS}"
 
-find "${DIR_PROG}" -type f -name '*.prog' -print0 | xargs -0 -n 1 -P ${JOBS} ./helper/prog2bm.sh
+find "${DIR_PROG}" -type f -name '*.prog' -print0 | xargs -r -0 -n 1 -P ${JOBS} ./helper/prog2bm.sh


### PR DESCRIPTION
Make parsing propagate tool failures and reject a successful-looking translation that emitted no syzlang programs. Also prevent xargs from invoking prog2bm with no arguments for an empty extraction directory.

Validation:
- mocked successful parser with zero output is rejected by 02_parse.sh
- 04_prepare.sh handles an empty input directory without invoking prog2bm
- bash syntax and diff checks pass

Signed-off-by: Martin Beck <martin.beck2@gmx.de>