### PR TITLE
[bm-external] Add another jiuwen like benchmark.

### DIFF
--- a/bm-external/bwrap/bm-bwrap.py
+++ b/bm-external/bwrap/bm-bwrap.py
@@ -220,7 +220,8 @@ def build_command(config: argparse.Namespace) -> list[str]:
         raise FileNotFoundError(f"bubblewrap executable not found: {config.bwrap}")
 
     config.network_namespace_used = False
-    if config.scenario in {"namespaces", "max"}:
+    print (config.turn_off_net_ns_usage)
+    if not config.turn_off_net_ns_usage and config.scenario in {"namespaces", "max", "jiuwen_code_agent"}:
         config.network_namespace_used = can_unshare_network(bwrap, command)
         if config.require_netns and not config.network_namespace_used:
             raise RuntimeError("bubblewrap network namespace probe failed")
@@ -268,6 +269,7 @@ if __name__ == "__main__":
     parser.add_argument("--index", type=int, default=0, help="Index of this execution unit")
     parser.add_argument("--units", type=int, default=1, help="Number of execution units")
     parser.add_argument("--iterations", type=int, default=100, help="Launches per execution unit")
+    parser.add_argument("--turn-off-net-ns-usage", action="store_true", help="Allows users to turn off network namespace usage, if the scenario uses it by default.")
     parser.add_argument(
         "--scenario",
         choices=["baseline", "namespaces", "filesystem", "max", "jiuwen_code_agent"],
@@ -294,13 +296,17 @@ if __name__ == "__main__":
     )
     args, _ = parser.parse_known_args()
 
+    print(args.turn_off_net_ns_usage)
     instance_name, launch_time, success_count = run_benchmark(args)
     avg_launch_time = launch_time / args.iterations if args.iterations else 0.0
+
+    network_namespace_used = bool(getattr(args, 'network_namespace_used', False))
+    network_namespace_used = "yes" if network_namespace_used else "no"
 
     print(
         f"instance_name={instance_name};"
         f"scenario={args.scenario};"
-        f"network_namespace={int(getattr(args, 'network_namespace_used', False))};"
+        f"network_namespace_used={network_namespace_used};"
         f"success_count={success_count};"
         f"launch_time={launch_time:.6f};"
         f"avg_launch_time={avg_launch_time:.6f};"

--- a/bm-external/bwrap/bm-bwrap.py
+++ b/bm-external/bwrap/bm-bwrap.py
@@ -220,7 +220,7 @@ def build_command(config: argparse.Namespace) -> list[str]:
         raise FileNotFoundError(f"bubblewrap executable not found: {config.bwrap}")
 
     config.network_namespace_used = False
-    if config.scenario in {"namespaces", "max", "jiuwen_code_agent"}:
+    if config.scenario in {"namespaces", "max"}:
         config.network_namespace_used = can_unshare_network(bwrap, command)
         if config.require_netns and not config.network_namespace_used:
             raise RuntimeError("bubblewrap network namespace probe failed")

--- a/bm-external/bwrap/bm-bwrap.py
+++ b/bm-external/bwrap/bm-bwrap.py
@@ -220,7 +220,6 @@ def build_command(config: argparse.Namespace) -> list[str]:
         raise FileNotFoundError(f"bubblewrap executable not found: {config.bwrap}")
 
     config.network_namespace_used = False
-    print (config.turn_off_net_ns_usage)
     if not config.turn_off_net_ns_usage and config.scenario in {"namespaces", "max", "jiuwen_code_agent"}:
         config.network_namespace_used = can_unshare_network(bwrap, command)
         if config.require_netns and not config.network_namespace_used:
@@ -296,7 +295,6 @@ if __name__ == "__main__":
     )
     args, _ = parser.parse_known_args()
 
-    print(args.turn_off_net_ns_usage)
     instance_name, launch_time, success_count = run_benchmark(args)
     avg_launch_time = launch_time / args.iterations if args.iterations else 0.0
 

--- a/config/bm-external/bwrap/jiuwen_code_agent.json
+++ b/config/bm-external/bwrap/jiuwen_code_agent.json
@@ -60,7 +60,7 @@
   },
   "containers": {
     "core_count": 1,
-    "container_list": {"values":[[6]]},
+    "container_list": {"values":[[160]]},
     "core_assignment_policy": {
       "cpu_order": "asc",
       "pack_group": "none",

--- a/config/bm-external/bwrap/jiuwen_code_agent.json
+++ b/config/bm-external/bwrap/jiuwen_code_agent.json
@@ -19,6 +19,15 @@
       "hue_lbl": "Executor",
       "shape": "barplot",
       "title": "bwrap Jiuwen-code-agent average launch time"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Benchmark Instances",
+      "y": "bpf_kernfs_remove_by_name_ns_hist",
+      "hue": "execution_type",
+      "hue_lbl": "Execution Env",
+      "title": "Duration of Kernfs_remove_by_name_ns",
+      "type": "bpftrace_hist"
     }
   ],
   "benchmark_config": {
@@ -44,12 +53,14 @@
         "bpf_cgroup_charge_hist.bt",
         "bpf_cgroup_fork_hist.bt",
         "bpf_cgroup_procs_write_hist.bt",
-        "bpf_cgroup_rstat_flush_hist.bt"
+        "bpf_cgroup_rstat_flush_hist.bt",
+        "bpf_kernfs_remove_by_name_ns_hist.bt"
       ]
     }
   },
   "containers": {
     "core_count": 1,
+    "container_list": {"values":[[6]]},
     "core_assignment_policy": {
       "cpu_order": "asc",
       "pack_group": "none",

--- a/config/bm-external/bwrap/jiuwen_code_agent.json
+++ b/config/bm-external/bwrap/jiuwen_code_agent.json
@@ -60,7 +60,6 @@
   },
   "containers": {
     "core_count": 1,
-    "container_list": {"values":[[160]]},
     "core_assignment_policy": {
       "cpu_order": "asc",
       "pack_group": "none",

--- a/config/bm-external/bwrap/jiuwen_code_agent_net_ns_off.json
+++ b/config/bm-external/bwrap/jiuwen_code_agent_net_ns_off.json
@@ -60,7 +60,7 @@
   },
   "containers": {
     "core_count": 1,
-    "container_list": {"values":[[6]]},
+    "container_list": {"values":[[160]]},
     "core_assignment_policy": {
       "cpu_order": "asc",
       "pack_group": "none",

--- a/config/bm-external/bwrap/jiuwen_code_agent_net_ns_off.json
+++ b/config/bm-external/bwrap/jiuwen_code_agent_net_ns_off.json
@@ -1,0 +1,77 @@
+{
+  "plots": [
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Benchmark Instances",
+      "y": "time",
+      "y_lbl": "Total Time(s)",
+      "hue": "execution_unit",
+      "hue_lbl": "Executor",
+      "shape": "barplot",
+      "title": "bwrap Jiuwen-code-agent launch time"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Benchmark Instances",
+      "y": "avg_launch_time",
+      "y_lbl": "Average Launch Time(s)",
+      "hue": "execution_unit",
+      "hue_lbl": "Executor",
+      "shape": "barplot",
+      "title": "bwrap Jiuwen-code-agent average launch time"
+    },
+    {
+      "x": "container_cnt",
+      "x_lbl": "#Benchmark Instances",
+      "y": "bpf_kernfs_remove_by_name_ns_hist",
+      "hue": "execution_type",
+      "hue_lbl": "Execution Env",
+      "title": "Duration of Kernfs_remove_by_name_ns",
+      "type": "bpftrace_hist"
+    }
+  ],
+  "benchmark_config": {
+    "exec_env": {
+      "native": []
+    },
+    "monitors": {
+      "mpstat": [
+        "-n",
+        "-u",
+        "-I",
+        "SCPU,SUM",
+        "-P",
+        "0"
+      ],
+      "perf": [
+        "-C",
+        "0"
+      ],
+      "perf_lock": [],
+      "bpftrace": [
+        "bpf_cgroup_attach_task_hist.bt",
+        "bpf_cgroup_charge_hist.bt",
+        "bpf_cgroup_fork_hist.bt",
+        "bpf_cgroup_procs_write_hist.bt",
+        "bpf_cgroup_rstat_flush_hist.bt",
+        "bpf_kernfs_remove_by_name_ns_hist.bt"
+      ]
+    }
+  },
+  "containers": {
+    "core_count": 1,
+    "container_list": {"values":[[6]]},
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "bm-external/bwrap",
+      "name": "bm-bwrap.py",
+      "args": "--index {index} --units {n_units} --iterations 1000 --scenario jiuwen_code_agent --command /usr/bin/true --turn-off-net-ns-usage"
+    }
+  ]
+}

--- a/config/bm-external/bwrap/jiuwen_code_agent_net_ns_off.json
+++ b/config/bm-external/bwrap/jiuwen_code_agent_net_ns_off.json
@@ -60,7 +60,6 @@
   },
   "containers": {
     "core_count": 1,
-    "container_list": {"values":[[160]]},
     "core_assignment_policy": {
       "cpu_order": "asc",
       "pack_group": "none",

--- a/doc/bm-external/bwrap.md
+++ b/doc/bm-external/bwrap.md
@@ -25,7 +25,7 @@ host runtime directories required to execute that command inside the sandbox.
 The network namespace is probed once per execution unit for the `namespaces`,
 `max`, and `jiuwen_code_agent` scenarios. If the installed bwrap cannot create it without extra
 privilege, the benchmark omits only `--unshare-net` and reports
-`network_namespace=0`; pass `--require-netns` in a config if that should be a
+`network_namespace_used=no`; pass `--require-netns` in a config if that should be a
 hard failure. The cgroup namespace uses `--unshare-cgroup-try` so the benchmark
 can still run on kernels or installations where cgroup namespace creation is not
 available.

--- a/scripts/bpftrace/bpf_kernfs_remove_by_name_ns_hist.bt
+++ b/scripts/bpftrace/bpf_kernfs_remove_by_name_ns_hist.bt
@@ -1,0 +1,13 @@
+kprobe:kernfs_remove_by_name_ns
+__FILTER__
+{
+    @start[tid] = nsecs;
+}
+
+kretprobe:kernfs_remove_by_name_ns
+/@start[tid]/
+{
+    $duration = (nsecs - @start[tid]) / 1000;
+    @kernfs_remove_by_name_ns_latency[pid, comm] = hist($duration);
+    delete(@start[tid]);
+}

--- a/scripts/bpftrace/bpf_kernfs_remove_by_name_ns_hist.bt
+++ b/scripts/bpftrace/bpf_kernfs_remove_by_name_ns_hist.bt
@@ -1,5 +1,4 @@
 kprobe:kernfs_remove_by_name_ns
-__FILTER__
 {
     @start[tid] = nsecs;
 }

--- a/scripts/bpftrace/bpf_kernfs_remove_by_name_ns_hist.bt
+++ b/scripts/bpftrace/bpf_kernfs_remove_by_name_ns_hist.bt
@@ -1,4 +1,5 @@
 kprobe:kernfs_remove_by_name_ns
+__FILTER__
 {
     @start[tid] = nsecs;
 }


### PR DESCRIPTION
Change

- add `--turn-off-net-ns-usage` option to bwrap benchmark
  to allow benchmarking jiuwen code-agent scenario with
  and without network namespaces.


Add

- benchmark configuration jiuwen_code_agent_net_ns_off.json
- bpftrace program to track `kernfs_remove_by_name_ns`