### PR TITLE
[bm-generator] Drop `CSB_SYZKALLER_FETCH` option.

### DIFF
--- a/bm-generator/CMakeLists.txt
+++ b/bm-generator/CMakeLists.txt
@@ -1,33 +1,15 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-include(FetchContent)
-
-option(CSB_SYZKALLER_FETCH "Allows syzkaller fetching in cmake ON/OFF" OFF)
-
 set(SYZKALLER syzkaller)
+set(SYZKALLER_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/syzkaller)
 add_custom_target(${SYZKALLER})
-
-if(CSB_SYZKALLER_FETCH)
-    # An alternative to using syzkaller as a submodule
-    FetchContent_Declare(
-        ${SYZKALLER}
-        GIT_REPOSITORY https://github.com/open-s4c/syzkaller.git
-        GIT_TAG f269e6fca74ba181096b1a6988e4316eaaa5870f
-        GIT_PROGRESS TRUE
-        EXCLUDE_FROM_ALL)
-
-    FetchContent_MakeAvailable(${SYZKALLER})
-
-    FetchContent_GetProperties(${SYZKALLER} SOURCE_DIR SYZKALLER_SOURCE_DIR)
-else()
-    set(SYZKALLER_SOURCE_DIR ${CMAKE_SOURCE_DIR}/deps/syzkaller)
-endif()
-
 find_program(GO_EXECUTABLE go)
+
 if(NOT GO_EXECUTABLE)
     message(FATAL_ERROR "Go compiler not found. Please install Go.")
 endif()
+
 message(STATUS "Go found at: ${GO_EXECUTABLE}")
 
 # Tools we want to build of syzkaller


### PR DESCRIPTION
Change

- drop the fetch content option for syzkaller
  it is used as a submodule all the time