### PR TITLE
bm-runner/bm_join_plot.py: fix PNG figure name

### DIFF
--- a/bm-runner/bm_join_plot.py
+++ b/bm-runner/bm_join_plot.py
@@ -319,7 +319,7 @@ def main() -> None:
     # Filter by app using pandas boolean indexing (exactly as requested)
     structured_plots: Dict[str, Dict[str, Dict[str, Dict[str, List[str]]]]] = {}
 
-    for machine in df["machine"].dropna().unique():
+    for machine_num, machine in enumerate(df["machine"].dropna().unique()):
         structured_plots[machine] = {}
 
         filter_machine = df["machine"] == machine
@@ -372,6 +372,7 @@ def main() -> None:
 
                     plot = PlotConfig(**plot_def)
                     plot.title = f"{host}: {title} ({etype_name})"
+                    plot.fname = f"{plot.fname}_{machine_num}_{etype_name}"
 
                     if title not in structured_plots[machine][app]:
                         structured_plots[machine][app][title] = {}


### PR DESCRIPTION
After commit #233, bm_join_plot stopped working, as container would override native images. Also, different machines would have identical images.

Fix it by ensuring an unique name along its run.