### PR TITLE
[bm-runner] Use more flexible data representation for table.

### DIFF
--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -27,7 +27,6 @@ def add_info_tbl(df, report: Report, result_file: str):
     table = []
     table.append(["Results file name:", result_file])
     for info in info_points:
-        row = []
         value = df[info].unique()
         if len(value) == 1:
             table.append([info, value[0]])

--- a/bm-runner/bm_visualize.py
+++ b/bm-runner/bm_visualize.py
@@ -22,18 +22,21 @@ import copy
 ###########################################################################
 def add_info_tbl(df, report: Report, result_file: str):
     info_points = [col for col in df.columns if df[col].nunique() == 1]
-    data = {}
-    data["Results file name:"] = result_file
+    # virtual table list of lists.
+    # each list is a row
+    table = []
+    table.append(["Results file name:", result_file])
     for info in info_points:
+        row = []
         value = df[info].unique()
         if len(value) == 1:
-            data[info] = value[0]
+            table.append([info, value[0]])
         else:
             vals = ",".join(str(v) for v in value)
             if not isinstance(value[0], str):
                 vals += f", mean = {statistics.mean(value)}"
-            data[info] = vals
-    report.add_table(data)
+            table.append([info, vals])
+    report.add_table(table)
 
 
 ###########################################################################

--- a/bm-runner/visual/report.py
+++ b/bm-runner/visual/report.py
@@ -91,13 +91,13 @@ class Report:
             case _:
                 self.doc.add(h2(name))
 
-    def add_table(self, data: dict[str, str]):
+    def add_table(self, tbl_data: list[list[str]]):
         tbl = table()
-        for k, v in data.items():
+        for r_data in tbl_data:
             row = tr()
-            row.add(td(k))
-            row.add(td(v))
             tbl.add(row)
+            for v in r_data:
+                row.add(td(v))
         self.doc.add(tbl)
 
     def embed_plots(self, plot_lists: list[list[str]], show_path: bool = True):


### PR DESCRIPTION
Change

- let `add_table` method accept a list of lists instead of a dict.
  allowing for adding tables with more than two columns if needed.