### PR TITLE
[bm-external] Fix rocksdb adapter.

### DIFF
--- a/scripts/adapters/rocksdb-adapter.sh
+++ b/scripts/adapters/rocksdb-adapter.sh
@@ -2,4 +2,4 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-awk '/operations/ {printf "%s%s=%d;", sep, $1, $5; sep=";"} END {printf("\n")}'
+awk '/operations/ {printf "%s%s=%d", sep, $1, $5; sep=";"} END {printf("\n")}'


### PR DESCRIPTION
Fix:

  - Fix rocksdb_adapter to avoid printing two consecutive semicolons.