### PR TITLE
[bm-generator] Fix stale network metadata in configs.

### DIFF
--- a/bm-generator/templates/CMakeLists.txt
+++ b/bm-generator/templates/CMakeLists.txt
@@ -84,7 +84,7 @@ foreach(HEADER ${HEADERS})
             else()
                 # otherwise set it to empty, and related section(s) will be
                 # turned off
-                set(META_NAME="")
+                set(META_NAME "")
             endif()
             set(TMPLR_PARAMS
                 -DPROBAVG="" -DPROBEND="1024"


### PR DESCRIPTION
Fix

- clear `META_NAME` when a generated benchmark has no network metadata

