### PR TITLE
[scripts] Fix frequency-mode perf event filtering.

### DIFF
--- a/scripts/fg-diff/filter.sh
+++ b/scripts/fg-diff/filter.sh
@@ -17,5 +17,5 @@ sudo perf script -i "$file" --dsos='[kernel.kallsyms]' | awk -vtarget="$target" 
 BEGIN {started = 0}
 started == 1 && NF==0 {started = 0; print;}
 started == 1 && $NF=="([kernel.kallsyms])" {print}
-$NF=="cycles:" || $NF=="cycles:P:" || $NF=="cpu-clock:" {if ($1 ~ target) {sub(target"[-]?[0-9]*", "THR")}; started = 1; print}
+$NF=="cycles:" || $NF=="cycles:P:" || $NF=="cpu-clock:" || $NF ~ /^cycles\/freq=[0-9]+\/:$/ {if ($1 ~ target) {sub(target"[-]?[0-9]*", "THR")}; started = 1; print}
 ' | "$FLAMEGRAPH"/stackcollapse-perf.pl | tee "$outfile.stacks" | "$FLAMEGRAPH"/flamegraph.pl --width=1920 --title="Flame graph: $(basename $outfile)" > "$outfile"

--- a/scripts/fg-merge/filter-merge-single.sh
+++ b/scripts/fg-merge/filter-merge-single.sh
@@ -16,5 +16,5 @@ sudo perf script -i "$file" --dsos='[kernel.kallsyms]' | awk -vtarget="$target" 
 BEGIN {started = 0}
 started == 1 && NF==0 {started = 0; print;}
 started == 1 && $NF=="([kernel.kallsyms])" {print}
-$NF=="cycles:" || $NF=="cycles:P:" || $NF=="cpu-clock:" {if ($1 ~ target) {sub(target"[-]?[0-9]*", "THR")}; started = 1; print}
+$NF=="cycles:" || $NF=="cycles:P:" || $NF=="cpu-clock:" || $NF ~ /^cycles\/freq=[0-9]+\/:$/ {if ($1 ~ target) {sub(target"[-]?[0-9]*", "THR")}; started = 1; print}
 '


### PR DESCRIPTION
Fix

- recognize frequency-mode cycle events in flamegraph filtering
- recognize the same events when merging selected flamegraphs

Note

- `perf script` prints `cycles/freq=99/:` for the frequency-mode
  event used by generated benchmark configs. The previous exact event
  checks ignored these samples and produced empty folded stacks.
- validated both paths with a k920b perf capture using
  `cycles/freq=99/`; filtering produced non-empty folded stacks and the
  merge parser emitted the expected perf-script records.
- `shellcheck`, `bash -n`, and `git diff --check` pass.
