### PR TITLE
bm-generator: fail fast during generation

### DIFF
--- a/bm-generator/05_generate.sh
+++ b/bm-generator/05_generate.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
+
+set -e
+
 cmake --build ../build --target syz_single.h.in
 cmake --build ../build --target fg_single.json.in


### PR DESCRIPTION
Fix

- stop benchmark generation when a CMake template target fails
- prevent later commands from hiding an earlier generation failure

Note

- PR #238 renames this script to `07_generate.sh`

Test

- `bash -n bm-generator/05_generate.sh`
- injected a failing `cmake` command and verified exit status 37
- verified only the first CMake target was attempted
