### PR TITLE
bm-generator: release wrapper resources

### DIFF
--- a/bm-generator/templates/syz_single.h.in
+++ b/bm-generator/templates/syz_single.h.in
@@ -84,34 +84,34 @@ static inline void init_subdirs_NN_prog(thread_ctx_t *ctx) {
   }
 }
 
-static void remove_tmp_dir_best_effort_NN_prog(const char *dir) {
-  DIR *dp = opendir(dir);
+static void remove_tmp_dir_contents_best_effort_NN_prog(int dirfd) {
+  DIR *dp = fdopendir(dirfd);
   if (dp == NULL) {
-    (void)rmdir(dir);
+    (void)close(dirfd);
     return;
   }
   struct dirent *entry = NULL;
   while ((entry = readdir(dp)) != NULL) {
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
       continue;
-    char path[FILENAME_MAX];
-    int len = snprintf(path, sizeof(path), "%s/%s", dir, entry->d_name);
-    if (len < 0 || (size_t)len >= sizeof(path))
-      continue;
-    struct stat st;
-    if (lstat(path, &st) != 0)
-      continue;
-    if (S_ISDIR(st.st_mode))
-      remove_tmp_dir_best_effort_NN_prog(path);
-    else
-      (void)unlink(path);
+    int childfd = openat(dirfd, entry->d_name,
+                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (childfd >= 0) {
+      remove_tmp_dir_contents_best_effort_NN_prog(childfd);
+      (void)unlinkat(dirfd, entry->d_name, AT_REMOVEDIR);
+    } else {
+      (void)unlinkat(dirfd, entry->d_name, 0);
+    }
   }
   (void)closedir(dp);
-  (void)rmdir(dir);
 }
 
 static inline void rm_tmpdir_NN_prog(thread_ctx_t *ctx) {
-  remove_tmp_dir_best_effort_NN_prog(ctx->tmpdir_NN_prog);
+  int cleanupfd = openat(ctx->dirfd_NN_prog, ".",
+                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (cleanupfd >= 0)
+    remove_tmp_dir_contents_best_effort_NN_prog(cleanupfd);
+  (void)rmdir(ctx->tmpdir_NN_prog);
 }
 $_end();
 
@@ -259,13 +259,13 @@ static inline void bm_target_dereg(thread_ctx_t *ctx, size_t tid) {
   // do the per test dereg
   bm_target_dereg_NN_prog(ctx);
 
+  rm_tmpdir_NN_prog(ctx);
   close(ctx->dirfd_NN_prog);
   ctx->dirfd_NN_prog = -1;
 
   munmap((void *)ctx->mmap_offsets_NN_prog, MMAP_LENGTH);
   ctx->mmap_offsets_NN_prog = 0;
 
-  rm_tmpdir_NN_prog(ctx);
   free(ctx->tmpdir_NN_prog);
   // free(ctx->connect_arg_NN_prog);
   ctx->tmpdir_NN_prog = NULL;

--- a/bm-generator/templates/syz_single.h.in
+++ b/bm-generator/templates/syz_single.h.in
@@ -84,9 +84,34 @@ static inline void init_subdirs_NN_prog(thread_ctx_t *ctx) {
   }
 }
 
-static void __attribute__((noinline)) remove_tmp_dir_NN_prog(const char *dir);
+static void remove_tmp_dir_best_effort_NN_prog(const char *dir) {
+  DIR *dp = opendir(dir);
+  if (dp == NULL) {
+    (void)rmdir(dir);
+    return;
+  }
+  struct dirent *entry = NULL;
+  while ((entry = readdir(dp)) != NULL) {
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+      continue;
+    char path[FILENAME_MAX];
+    int len = snprintf(path, sizeof(path), "%s/%s", dir, entry->d_name);
+    if (len < 0 || (size_t)len >= sizeof(path))
+      continue;
+    struct stat st;
+    if (lstat(path, &st) != 0)
+      continue;
+    if (S_ISDIR(st.st_mode))
+      remove_tmp_dir_best_effort_NN_prog(path);
+    else
+      (void)unlink(path);
+  }
+  (void)closedir(dp);
+  (void)rmdir(dir);
+}
+
 static inline void rm_tmpdir_NN_prog(thread_ctx_t *ctx) {
-  remove_tmp_dir_NN_prog(ctx->tmpdir_NN_prog);
+  remove_tmp_dir_best_effort_NN_prog(ctx->tmpdir_NN_prog);
 }
 $_end();
 

--- a/bm-generator/templates/syz_single.h.in
+++ b/bm-generator/templates/syz_single.h.in
@@ -11,6 +11,7 @@
 #include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <linux/openat2.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -18,6 +19,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 
 #define BM_CTX_TID (ctx->tid)
@@ -94,8 +96,12 @@ static void remove_tmp_dir_contents_best_effort_NN_prog(int dirfd) {
   while ((entry = readdir(dp)) != NULL) {
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
       continue;
-    int childfd = openat(dirfd, entry->d_name,
-                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    const struct open_how how = {
+        .flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+        .resolve = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_XDEV,
+    };
+    int childfd =
+        syscall(SYS_openat2, dirfd, entry->d_name, &how, sizeof(how));
     if (childfd >= 0) {
       remove_tmp_dir_contents_best_effort_NN_prog(childfd);
       (void)unlinkat(dirfd, entry->d_name, AT_REMOVEDIR);

--- a/bm-generator/templates/syz_single.h.in
+++ b/bm-generator/templates/syz_single.h.in
@@ -234,6 +234,13 @@ static inline void bm_target_dereg(thread_ctx_t *ctx, size_t tid) {
   // do the per test dereg
   bm_target_dereg_NN_prog(ctx);
 
+  close(ctx->dirfd_NN_prog);
+  ctx->dirfd_NN_prog = -1;
+
+  munmap((void *)ctx->mmap_offsets_NN_prog, MMAP_LENGTH);
+  ctx->mmap_offsets_NN_prog = 0;
+
+  rm_tmpdir_NN_prog(ctx);
   free(ctx->tmpdir_NN_prog);
   // free(ctx->connect_arg_NN_prog);
   ctx->tmpdir_NN_prog = NULL;

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -227,6 +227,13 @@ static inline void bm_target_dereg(thread_ctx_t *ctx, size_t tid) {
   // do the per test dereg
   bm_target_dereg_NN_prog(ctx);
 
+  close(ctx->dirfd_NN_prog);
+  ctx->dirfd_NN_prog = -1;
+
+  munmap((void *)ctx->mmap_offsets_NN_prog, MMAP_LENGTH);
+  ctx->mmap_offsets_NN_prog = 0;
+
+  rm_tmpdir_NN_prog(ctx);
   free(ctx->tmpdir_NN_prog);
   // free(ctx->connect_arg_NN_prog);
   ctx->tmpdir_NN_prog = NULL;

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -84,34 +84,34 @@ static inline void init_subdirs_NN_prog(thread_ctx_t *ctx) {
   }
 }
 
-static void remove_tmp_dir_best_effort_NN_prog(const char *dir) {
-  DIR *dp = opendir(dir);
+static void remove_tmp_dir_contents_best_effort_NN_prog(int dirfd) {
+  DIR *dp = fdopendir(dirfd);
   if (dp == NULL) {
-    (void)rmdir(dir);
+    (void)close(dirfd);
     return;
   }
   struct dirent *entry = NULL;
   while ((entry = readdir(dp)) != NULL) {
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
       continue;
-    char path[FILENAME_MAX];
-    int len = snprintf(path, sizeof(path), "%s/%s", dir, entry->d_name);
-    if (len < 0 || (size_t)len >= sizeof(path))
-      continue;
-    struct stat st;
-    if (lstat(path, &st) != 0)
-      continue;
-    if (S_ISDIR(st.st_mode))
-      remove_tmp_dir_best_effort_NN_prog(path);
-    else
-      (void)unlink(path);
+    int childfd = openat(dirfd, entry->d_name,
+                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (childfd >= 0) {
+      remove_tmp_dir_contents_best_effort_NN_prog(childfd);
+      (void)unlinkat(dirfd, entry->d_name, AT_REMOVEDIR);
+    } else {
+      (void)unlinkat(dirfd, entry->d_name, 0);
+    }
   }
   (void)closedir(dp);
-  (void)rmdir(dir);
 }
 
 static inline void rm_tmpdir_NN_prog(thread_ctx_t *ctx) {
-  remove_tmp_dir_best_effort_NN_prog(ctx->tmpdir_NN_prog);
+  int cleanupfd = openat(ctx->dirfd_NN_prog, ".",
+                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (cleanupfd >= 0)
+    remove_tmp_dir_contents_best_effort_NN_prog(cleanupfd);
+  (void)rmdir(ctx->tmpdir_NN_prog);
 }
 $_end();
 
@@ -252,13 +252,13 @@ static inline void bm_target_dereg(thread_ctx_t *ctx, size_t tid) {
   // do the per test dereg
   bm_target_dereg_NN_prog(ctx);
 
+  rm_tmpdir_NN_prog(ctx);
   close(ctx->dirfd_NN_prog);
   ctx->dirfd_NN_prog = -1;
 
   munmap((void *)ctx->mmap_offsets_NN_prog, MMAP_LENGTH);
   ctx->mmap_offsets_NN_prog = 0;
 
-  rm_tmpdir_NN_prog(ctx);
   free(ctx->tmpdir_NN_prog);
   // free(ctx->connect_arg_NN_prog);
   ctx->tmpdir_NN_prog = NULL;

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -84,9 +84,34 @@ static inline void init_subdirs_NN_prog(thread_ctx_t *ctx) {
   }
 }
 
-static void __attribute__((noinline)) remove_tmp_dir_NN_prog(const char *dir);
+static void remove_tmp_dir_best_effort_NN_prog(const char *dir) {
+  DIR *dp = opendir(dir);
+  if (dp == NULL) {
+    (void)rmdir(dir);
+    return;
+  }
+  struct dirent *entry = NULL;
+  while ((entry = readdir(dp)) != NULL) {
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+      continue;
+    char path[FILENAME_MAX];
+    int len = snprintf(path, sizeof(path), "%s/%s", dir, entry->d_name);
+    if (len < 0 || (size_t)len >= sizeof(path))
+      continue;
+    struct stat st;
+    if (lstat(path, &st) != 0)
+      continue;
+    if (S_ISDIR(st.st_mode))
+      remove_tmp_dir_best_effort_NN_prog(path);
+    else
+      (void)unlink(path);
+  }
+  (void)closedir(dp);
+  (void)rmdir(dir);
+}
+
 static inline void rm_tmpdir_NN_prog(thread_ctx_t *ctx) {
-  remove_tmp_dir_NN_prog(ctx->tmpdir_NN_prog);
+  remove_tmp_dir_best_effort_NN_prog(ctx->tmpdir_NN_prog);
 }
 $_end();
 

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -11,6 +11,7 @@
 #include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <linux/openat2.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -18,6 +19,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 
 #define BM_CTX_TID (ctx->tid)
@@ -94,8 +96,12 @@ static void remove_tmp_dir_contents_best_effort_NN_prog(int dirfd) {
   while ((entry = readdir(dp)) != NULL) {
     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
       continue;
-    int childfd = openat(dirfd, entry->d_name,
-                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    const struct open_how how = {
+        .flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC,
+        .resolve = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_XDEV,
+    };
+    int childfd =
+        syscall(SYS_openat2, dirfd, entry->d_name, &how, sizeof(how));
     if (childfd >= 0) {
       remove_tmp_dir_contents_best_effort_NN_prog(childfd);
       (void)unlinkat(dirfd, entry->d_name, AT_REMOVEDIR);

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -11,7 +11,6 @@
 #include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <linux/openat2.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -19,7 +18,6 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/syscall.h>
 #include <sys/types.h>
 
 #define BM_CTX_TID (ctx->tid)
@@ -86,38 +84,9 @@ static inline void init_subdirs_NN_prog(thread_ctx_t *ctx) {
   }
 }
 
-static void remove_tmp_dir_contents_best_effort_NN_prog(int dirfd) {
-  DIR *dp = fdopendir(dirfd);
-  if (dp == NULL) {
-    (void)close(dirfd);
-    return;
-  }
-  struct dirent *entry = NULL;
-  while ((entry = readdir(dp)) != NULL) {
-    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-      continue;
-    const struct open_how how = {
-        .flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC,
-        .resolve = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_XDEV,
-    };
-    int childfd =
-        syscall(SYS_openat2, dirfd, entry->d_name, &how, sizeof(how));
-    if (childfd >= 0) {
-      remove_tmp_dir_contents_best_effort_NN_prog(childfd);
-      (void)unlinkat(dirfd, entry->d_name, AT_REMOVEDIR);
-    } else {
-      (void)unlinkat(dirfd, entry->d_name, 0);
-    }
-  }
-  (void)closedir(dp);
-}
-
+static void __attribute__((noinline)) remove_tmp_dir_NN_prog(const char *dir);
 static inline void rm_tmpdir_NN_prog(thread_ctx_t *ctx) {
-  int cleanupfd = openat(ctx->dirfd_NN_prog, ".",
-                         O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-  if (cleanupfd >= 0)
-    remove_tmp_dir_contents_best_effort_NN_prog(cleanupfd);
-  (void)rmdir(ctx->tmpdir_NN_prog);
+  remove_tmp_dir_NN_prog(ctx->tmpdir_NN_prog);
 }
 $_end();
 
@@ -257,13 +226,6 @@ static inline void bm_target_dereg(thread_ctx_t *ctx, size_t tid) {
   $_begin(NN = [[1; 2]]);
   // do the per test dereg
   bm_target_dereg_NN_prog(ctx);
-
-  rm_tmpdir_NN_prog(ctx);
-  close(ctx->dirfd_NN_prog);
-  ctx->dirfd_NN_prog = -1;
-
-  munmap((void *)ctx->mmap_offsets_NN_prog, MMAP_LENGTH);
-  ctx->mmap_offsets_NN_prog = 0;
 
   free(ctx->tmpdir_NN_prog);
   // free(ctx->connect_arg_NN_prog);


### PR DESCRIPTION
Fix

- close each generated wrapper's temporary-directory descriptor
- unmap its per-thread syzkaller data mapping
- remove its temporary directory before freeing the path buffer
- ignore every temporary-directory cleanup error

Note

- use a template-local cleanup helper without changing syzkaller's executor

Test

- configured CMake with `CSB_BM_GENERATOR=ON`
- built the `tmplr-build` target
- generated both `syz_single` template variants successfully
- verified cleanup presence and ordering in both generated headers
- verified the local remover has no assertion, exit, or retry loop
- `git diff --check`
