### PR TITLE
[bm-generator] Reset operation counters per dispatch.

### DIFF
--- a/bm-generator/templates/syz_single.h.in
+++ b/bm-generator/templates/syz_single.h.in
@@ -316,6 +316,8 @@ static inline bm_op_res_t bm_dispatch_operation(thread_ctx_t *ctx,
   res_all.op_count = 0;
   res_all.succ_count = 0;
   $_begin(NN = [[1; 2]]);
+  ctx->num_succeeded_NN_prog = 0;
+  ctx->num_failed_NN_prog = 0;
   bm_dispatch_operation_NN_prog(ctx, op_id);
   res_all.op_count += ctx->num_succeeded_NN_prog + ctx->num_failed_NN_prog;
   res_all.succ_count += ctx->num_succeeded_NN_prog;

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -271,8 +271,6 @@ static inline bm_op_res_t bm_dispatch_operation(thread_ctx_t *ctx,
   res_all.op_count = 0;
   res_all.succ_count = 0;
   $_begin(NN = [[1; 2]]);
-  ctx->num_succeeded_NN_prog = 0;
-  ctx->num_failed_NN_prog = 0;
   bm_dispatch_operation_NN_prog(ctx, op_id);
   res_all.op_count += ctx->num_succeeded_NN_prog + ctx->num_failed_NN_prog;
   res_all.succ_count += ctx->num_succeeded_NN_prog;

--- a/bm-generator/templates/syz_single_v2.0.1.h.in
+++ b/bm-generator/templates/syz_single_v2.0.1.h.in
@@ -271,6 +271,8 @@ static inline bm_op_res_t bm_dispatch_operation(thread_ctx_t *ctx,
   res_all.op_count = 0;
   res_all.succ_count = 0;
   $_begin(NN = [[1; 2]]);
+  ctx->num_succeeded_NN_prog = 0;
+  ctx->num_failed_NN_prog = 0;
   bm_dispatch_operation_NN_prog(ctx, op_id);
   res_all.op_count += ctx->num_succeeded_NN_prog + ctx->num_failed_NN_prog;
   res_all.succ_count += ctx->num_succeeded_NN_prog;


### PR DESCRIPTION
Fix

- reset generated success and failure counters before each dispatch
  and prevent operation statistics from accumulating across dispatches.
