### PR TITLE
Add remote kernel patch validation skill

### DIFF
--- a/.agents/skills/csb-kernel-validate/SKILL.md
+++ b/.agents/skills/csb-kernel-validate/SKILL.md
@@ -14,6 +14,11 @@ remote boot configuration or installing a kernel. Read
 first build and again before every reboot. Read and apply
 [references/access-safety.md](references/access-safety.md) before the first
 change to networking, SSH, bootloader, watchdog, panic, or reboot configuration.
+Read and complete
+[references/host-recovery-safety.md](references/host-recovery-safety.md) before
+the first mutation of any remote host. Perform only read-only inventory and
+non-mutating probes until its off-host gate record passes. Re-run affected gates
+whenever recovery, storage, boot, access, watchdog, or baseline state changes.
 
 ## Preconditions
 
@@ -26,6 +31,11 @@ change to networking, SSH, bootloader, watchdog, panic, or reboot configuration.
 - Record dirty state, running kernel release and build ID, bootloader, firmware,
   root filesystem, free `/boot` space, console/BMC access, watchdog capability,
   and the exact persistent stable boot entry.
+- Require proven out-of-band console, power/reset, and recovery-media control; a
+  boot-tested rescue environment independent of the normal root filesystem; two
+  clean stable baseline boots; and a verified off-host baseline plus restorable
+  native snapshot or image. If any required layer cannot be tested, stop before
+  changing the host.
 - Probe the remote machine against the reboot-readiness reference. Inventory all
   prerequisites and volatile state, move campaign-critical inputs, logs, ledgers,
   build state, credentials/configuration, and restart instructions from tmpfs or
@@ -38,9 +48,18 @@ change to networking, SSH, bootloader, watchdog, panic, or reboot configuration.
   tested, generously timed stable-kernel rollback before each risky change. Keep
   access credentials restricted and never weaken SSH or firewall policy merely
   to make the tunnel work.
+- Treat direct SSH, reverse or separately routed SSH, and out-of-band management
+  as three distinct required access layers. SSH and OS-level timers do not cover
+  failures before init, root mount, networking, or SSH startup.
 - Require a verified one-shot boot path that leaves the stable kernel as the
   persistent default. If unavailable, stop before reboot and report the missing
   recovery mechanism. A timeout alone is not recovery.
+- Separate stable-host recovery provisioning from candidate installation.
+  Candidate installers must not re-execute PID 1, first-enable or shorten a
+  watchdog, change SSH/networking, or apply live global panic policy. Prohibit
+  `systemctl daemon-reexec` and equivalent service-manager re-execution during
+  validation. Activate and load-test watchdog policy through a planned stable
+  boot before installing candidates.
 
 ## Candidate Loop
 
@@ -61,18 +80,21 @@ the user supplies another budget. For each candidate:
    logged exit statuses. Run the relevant narrow object/subsystem tests plus the
    kernel's build-time checks. Verify image, modules, initramfs, symbol/map, and
    release-name consistency before installation.
-4. **Arm access and recovery.** Verify both SSH paths from end to end, preserve
+4. **Arm access and recovery.** Verify both SSH paths and out-of-band recovery
+   from end to end, preserve
    their logs outside tmpfs, and arm the pre-change stable rollback before any
-   reboot-safety mutation. Keep the known-good kernel persistent default, install the
-   uniquely named candidate beside it, enable panic/oops reboot, configure and
-   verify a hardware watchdog when available, and prepare a post-boot bailout
-   timer. Select the candidate for one boot only. Save bootloader state and the
-   commands needed to undo every change.
+   reboot-safety mutation. Reverify the independent rescue boot and baseline
+   snapshot/image. Keep the known-good kernel persistent default, install the
+   uniquely named candidate beside it, use candidate command-line panic/oops
+   policy, verify the already provisioned and stable-load-tested watchdog, and
+   prepare a post-boot bailout timer. Select the candidate for one boot only.
+   Save bootloader state and the commands needed to undo every change.
 5. **Preflight and reboot.** Run the complete reboot-readiness and access-safety
    gates. Recheck idle
    state, stable default, candidate
    one-shot entry, filesystem health, free space, initramfs contents, root-device
-   support, network driver, SSH service, watchdog, durable logs, persistent
+   support, network driver, SSH service, watchdog, rescue boot, snapshot/image
+   rollback, out-of-band console capture, durable logs, persistent
    campaign state, both SSH paths, armed rollback/bailout state, and the tested
    post-boot continuation command. Reboot once.
    Poll with bounded reconnect attempts; use BMC/console evidence when available.
@@ -123,6 +145,7 @@ patches/          each candidate and source commit
 build/            commands, logs, exit-status ledger, artifact hashes
 boot/             preflight, bootloader state, watchdog, journal/dmesg
 access/           direct/reverse SSH probes, service state, rollback timers/logs
+recovery/         OOB proof, rescue boot, baseline backup/snapshot, restore test
 stable/           baseline results and analysis
 candidate-N/      results, analysis, refine reports, health evidence
 comparison/       A/B tables, statistics, decision and iteration ledger

--- a/.agents/skills/csb-kernel-validate/SKILL.md
+++ b/.agents/skills/csb-kernel-validate/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: csb-kernel-validate
+description: "Use when an evidence-backed Linux kernel patch from csb-analysis and csb-refine must be built, installed, recovery-booted, and benchmarked on a remote CSB host. Compose csb-analysis, csb-refine, and csb-remote to compare stable and patched kernels, reject unmeasurable or unsafe candidates, and iterate toward a functional scalability improvement."
+---
+
+# CSB Kernel Validate
+
+Turn a CSB-derived RFC patch into a controlled remote A/B experiment. Load and
+follow `csb-analysis`, `csb-refine`, and `csb-remote`; use `csb` for benchmark
+execution. Preserve their evidence, cleanup, copy-back, and reporting rules.
+Read [references/boot-safety.md](references/boot-safety.md) before changing a
+remote boot configuration or installing a kernel. Read
+[references/reboot-readiness.md](references/reboot-readiness.md) before the
+first build and again before every reboot.
+
+## Preconditions
+
+- Require an identified remote host, remote CSB checkout, complete stable-kernel
+  result set, matching Linux source/config, patch artifact, and focused rerun
+  matrix from the refinement report.
+- Obtain authorization for package installation, bootloader changes, kernel
+  installation, and reboot unless the user's request already explicitly covers
+  them. Never reboot while unrelated campaigns or users are active.
+- Record dirty state, running kernel release and build ID, bootloader, firmware,
+  root filesystem, free `/boot` space, console/BMC access, watchdog capability,
+  and the exact persistent stable boot entry.
+- Probe the remote machine against the reboot-readiness reference. Inventory all
+  prerequisites and volatile state, move campaign-critical inputs, logs, ledgers,
+  build state, credentials/configuration, and restart instructions from tmpfs or
+  other ephemeral storage to persistent storage, and copy the recovery manifest
+  off-host. Do not assume `/tmp`, `/run`, `/dev/shm`, tmux, shell state, runtime
+  directories, temporary mounts, or manually applied host tuning survives reboot.
+- Require a verified one-shot boot path that leaves the stable kernel as the
+  persistent default. If unavailable, stop before reboot and report the missing
+  recovery mechanism. A timeout alone is not recovery.
+
+## Candidate Loop
+
+Use a durable iteration ledger. Default to at most three patch candidates unless
+the user supplies another budget. For each candidate:
+
+1. **Freeze the comparison.** Record the stable kernel identity, source commit,
+   config hash, compiler/toolchain, firmware/microcode, CSB commit, config hash,
+   topology, runtime state, and original analysis/refinement artifacts. Predeclare
+   primary metric, tested scaling points, repetitions, noise threshold, acceptance
+   rule, correctness checks, and material regressions.
+2. **Prepare the source remotely.** Use an isolated remote worktree matching the
+   stable kernel source. Preserve localversion and provenance, apply the patch
+   with `git apply --check`, then apply it. Do not disturb the host's existing
+   kernel tree or CSB checkout.
+3. **Build and verify.** Reuse the stable kernel config, run the appropriate
+   `olddefconfig`, build the kernel, modules, and required initramfs/package with
+   logged exit statuses. Run the relevant narrow object/subsystem tests plus the
+   kernel's build-time checks. Verify image, modules, initramfs, symbol/map, and
+   release-name consistency before installation.
+4. **Arm recovery.** Keep the known-good kernel persistent default, install the
+   uniquely named candidate beside it, enable panic/oops reboot, configure and
+   verify a hardware watchdog when available, and select the candidate for one
+   boot only. Save bootloader state and the commands needed to undo every change.
+5. **Preflight and reboot.** Run the complete reboot-readiness gate. Recheck idle
+   state, stable default, candidate
+   one-shot entry, filesystem health, free space, initramfs contents, root-device
+   support, network driver, SSH service, watchdog, durable logs, persistent
+   campaign state, and the tested post-boot continuation command. Reboot once.
+   Poll with bounded reconnect attempts; use BMC/console evidence when available.
+6. **Verify identity and health.** Do not benchmark merely because SSH returned.
+   Confirm hostname, `uname -r`, build ID/version, `/proc/cmdline`, loaded modules,
+   boot ID, bootloader state, mounts, filesystems, storage/network health, and
+   current-boot kernel logs. Re-probe campaign prerequisites, restore only the
+   recorded transient host setup, and verify persistent inputs and ledgers before
+   resuming. Confirm the stable kernel remains the next reboot's persistent
+   default. On oops, panic, corruption warning, missing prerequisite, service
+   failure, wrong kernel, or unexplained reboot, preserve logs and reject or block
+   the candidate rather than starting a partial campaign.
+7. **Rerun the evidence workflow.** Repeat the same focused CSB matrix and the
+   same `csb-analysis` and `csb-refine` process used for the stable result. Keep
+   execution types and monitor variants separate. Include monitor-off runs and
+   correctness/success-rate checks. Do not compare runs with different workload,
+   config, CPU policy, frequency policy, topology, runtime, or environment.
+8. **Compare.** Prefer interleaved stable/patched boots when practical; otherwise
+   bracket patched measurements with stable runs. Use enough repetitions to
+   estimate run-to-run noise. Report raw values, median and spread/confidence
+   interval, effect size, scaling-curve changes, resource movement, profiler
+   evidence, failures, and regressions. Never infer improvement from a single run.
+9. **Decide.** Accept only when the predeclared primary scalability improvement
+   is larger than noise, repeatable, explained by the expected kernel-path
+   movement, functionally correct, and free of material regressions. Reject when
+   unsafe, incorrect, or confidently neutral/negative. Mark inconclusive when
+   uncertainty is too large; sharpen the experiment before changing the patch.
+10. **Iterate or finish.** For a rejected/inconclusive performance candidate,
+    use the combined analysis to state why the hypothesis failed and design the
+    smallest evidence-backed successor patch. Return to step 2. Stop at the
+    iteration budget, a non-kernel bottleneck, insufficient evidence, unavailable
+    recovery, or semantic uncertainty; do not invent a patch to force success.
+
+After every candidate, boot back into the stable kernel with a one-shot selection
+when necessary, verify its identity and health, and preserve the candidate kernel
+until all evidence and recovery logs have been copied back. Do not delete kernels
+or results unless explicitly requested.
+
+## Durable Artifacts
+
+Store controller copies under
+`results/remote/<remote>/<task>/kernel-validation/`:
+
+```text
+inventory/        stable and candidate identities, configs, boot state
+continuation/     prerequisite probes, volatile-state inventory, restart manifest
+patches/          each candidate and source commit
+build/            commands, logs, exit-status ledger, artifact hashes
+boot/             preflight, bootloader state, watchdog, journal/dmesg
+stable/           baseline results and analysis
+candidate-N/      results, analysis, refine reports, health evidence
+comparison/       A/B tables, statistics, decision and iteration ledger
+```
+
+For each attempted boot, record candidate, timestamps, old/new boot IDs, expected
+entry, observed kernel, reconnect outcome, fatal evidence, fallback outcome, and
+stable-kernel recovery verification. A `.done` marker or reachable SSH session is
+not proof of a successful kernel validation.
+
+## Final Outcome
+
+Classify the patch as `accepted`, `rejected`, `inconclusive`, or `blocked`. State
+the exact kernel identities, build and boot verification, fallback status,
+benchmark deltas and uncertainty, correctness results, profiler-path change,
+regressions, iterations attempted, copied-back paths, and any cleanup intentionally
+left for recovery. An accepted patch remains an RFC until its wider correctness,
+subsystem, architecture, and upstream review requirements are satisfied.

--- a/.agents/skills/csb-kernel-validate/SKILL.md
+++ b/.agents/skills/csb-kernel-validate/SKILL.md
@@ -11,7 +11,9 @@ execution. Preserve their evidence, cleanup, copy-back, and reporting rules.
 Read [references/boot-safety.md](references/boot-safety.md) before changing a
 remote boot configuration or installing a kernel. Read
 [references/reboot-readiness.md](references/reboot-readiness.md) before the
-first build and again before every reboot.
+first build and again before every reboot. Read and apply
+[references/access-safety.md](references/access-safety.md) before the first
+change to networking, SSH, bootloader, watchdog, panic, or reboot configuration.
 
 ## Preconditions
 
@@ -30,6 +32,12 @@ first build and again before every reboot.
   other ephemeral storage to persistent storage, and copy the recovery manifest
   off-host. Do not assume `/tmp`, `/run`, `/dev/shm`, tmux, shell state, runtime
   directories, temporary mounts, or manually applied host tuning survives reboot.
+- Establish and test two independent SSH paths before reboot-related mutation:
+  a controller-side reconnecting SSH client in a dedicated tmux/screen session,
+  and a remote-supervised reverse SSH tunnel to a controller endpoint. Arm a
+  tested, generously timed stable-kernel rollback before each risky change. Keep
+  access credentials restricted and never weaken SSH or firewall policy merely
+  to make the tunnel work.
 - Require a verified one-shot boot path that leaves the stable kernel as the
   persistent default. If unavailable, stop before reboot and report the missing
   recovery mechanism. A timeout alone is not recovery.
@@ -53,15 +61,20 @@ the user supplies another budget. For each candidate:
    logged exit statuses. Run the relevant narrow object/subsystem tests plus the
    kernel's build-time checks. Verify image, modules, initramfs, symbol/map, and
    release-name consistency before installation.
-4. **Arm recovery.** Keep the known-good kernel persistent default, install the
+4. **Arm access and recovery.** Verify both SSH paths from end to end, preserve
+   their logs outside tmpfs, and arm the pre-change stable rollback before any
+   reboot-safety mutation. Keep the known-good kernel persistent default, install the
    uniquely named candidate beside it, enable panic/oops reboot, configure and
-   verify a hardware watchdog when available, and select the candidate for one
-   boot only. Save bootloader state and the commands needed to undo every change.
-5. **Preflight and reboot.** Run the complete reboot-readiness gate. Recheck idle
+   verify a hardware watchdog when available, and prepare a post-boot bailout
+   timer. Select the candidate for one boot only. Save bootloader state and the
+   commands needed to undo every change.
+5. **Preflight and reboot.** Run the complete reboot-readiness and access-safety
+   gates. Recheck idle
    state, stable default, candidate
    one-shot entry, filesystem health, free space, initramfs contents, root-device
    support, network driver, SSH service, watchdog, durable logs, persistent
-   campaign state, and the tested post-boot continuation command. Reboot once.
+   campaign state, both SSH paths, armed rollback/bailout state, and the tested
+   post-boot continuation command. Reboot once.
    Poll with bounded reconnect attempts; use BMC/console evidence when available.
 6. **Verify identity and health.** Do not benchmark merely because SSH returned.
    Confirm hostname, `uname -r`, build ID/version, `/proc/cmdline`, loaded modules,
@@ -109,6 +122,7 @@ continuation/     prerequisite probes, volatile-state inventory, restart manifes
 patches/          each candidate and source commit
 build/            commands, logs, exit-status ledger, artifact hashes
 boot/             preflight, bootloader state, watchdog, journal/dmesg
+access/           direct/reverse SSH probes, service state, rollback timers/logs
 stable/           baseline results and analysis
 candidate-N/      results, analysis, refine reports, health evidence
 comparison/       A/B tables, statistics, decision and iteration ledger

--- a/.agents/skills/csb-kernel-validate/agents/openai.yaml
+++ b/.agents/skills/csb-kernel-validate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CSB Kernel Validate"
+  short_description: "Safely validate remote CSB kernel patches"
+  default_prompt: "Use $csb-kernel-validate to deploy and validate this CSB-derived kernel patch on the remote benchmark host."

--- a/.agents/skills/csb-kernel-validate/references/access-safety.md
+++ b/.agents/skills/csb-kernel-validate/references/access-safety.md
@@ -2,8 +2,14 @@
 
 Complete this gate before changing networking, firewall, SSH, bootloader,
 watchdog, panic, or reboot configuration. Use two independently tested SSH paths
-plus timed rollback. Console/BMC access remains preferable and must be recorded
-when available.
+plus timed rollback. Independently tested out-of-band console, power/reset, and
+recovery-media control is mandatory and must be recorded.
+
+Also complete
+[host-recovery-safety.md](host-recovery-safety.md) before any host mutation.
+Out-of-band recovery is mandatory for kernel validation: two SSH paths plus
+OS-level timers cannot recover early-boot, root-filesystem, loader, or PID 1
+failures.
 
 ## Direct Persistent Controller Session
 
@@ -108,3 +114,8 @@ After recovery, verify the stable kernel and new boot ID, collect previous-boot
 journal/pstore/console logs and rollback evidence, classify the triggering change,
 and stop the candidate campaign until access safety is restored. Absence of a
 rollback log is not proof that the timer did not fire.
+
+If the host cannot execute init, mount its normal root, or start either SSH path,
+stop retrying OS-level recovery. Use the tested out-of-band console and
+independent rescue environment, preserve serial/reset evidence, mount storage
+read-only first, and copy diagnostics off-host before repair.

--- a/.agents/skills/csb-kernel-validate/references/access-safety.md
+++ b/.agents/skills/csb-kernel-validate/references/access-safety.md
@@ -1,0 +1,110 @@
+# Remote Access and Timed Rollback Safety
+
+Complete this gate before changing networking, firewall, SSH, bootloader,
+watchdog, panic, or reboot configuration. Use two independently tested SSH paths
+plus timed rollback. Console/BMC access remains preferable and must be recorded
+when available.
+
+## Direct Persistent Controller Session
+
+Create a dedicated controller-side tmux or screen session containing a direct SSH
+client with `ServerAliveInterval`, `ServerAliveCountMax`, TCP keepalives, connection
+timeout, and a reconnect loop with bounded backoff. Use a unique task-specific
+session name and log reconnect timestamps to persistent controller storage. Do
+not reuse or kill unrelated sessions.
+
+Verify the session reaches the expected host and records hostname, host key,
+running kernel, boot ID, source address, and route. Detaching tmux preserves the
+controller process across terminal loss; it does not preserve the remote TCP
+connection or survive a controller reboot. The reconnect loop must therefore be
+tested by closing one SSH child and observing a successful reconnect.
+
+## Reverse SSH Recovery Path
+
+Establish a second path initiated by the remote host toward a known controller or
+jump endpoint. Prefer `autossh` or a systemd service around OpenSSH using
+`ExitOnForwardFailure=yes`, keepalives, `Restart=always`, and restart backoff. Bind
+the reverse listening port to controller loopback unless broader exposure is
+explicitly required. Use a unique allocated port and record both endpoints.
+
+Use a dedicated restricted key or existing task-authorized credential. Restrict
+the controller-side key and account to the required reverse forwarding and deny
+unneeded shell, agent, X11, and additional forwarding capabilities when supported.
+Verify host keys; do not disable checking, expose a reverse port publicly, copy
+general-purpose credentials, alter `sshd_config`, or open a firewall broadly just
+to establish recovery access.
+
+Run the reverse client under remote supervision from persistent configuration,
+not `/tmp`, a shell, or a tmux process. If it must reconnect after reboot, enable
+it only after verifying its boot ordering, network dependency, credential path,
+ownership, modes, logs, and failure behavior. Ensure it cannot start the campaign.
+
+From the controller, open a separate SSH connection through the reverse port and
+verify hostname, host key, kernel, boot ID, and source path. Then deliberately
+restart only the reverse-tunnel service and prove that the tunnel disappears and
+returns. Do not disrupt the host's primary network to test it. A tunnel is ready
+only when direct and reverse connections work concurrently and independently.
+
+## Pre-Change Stable Rollback
+
+Before the first risky mutation, install a task-specific rollback script and
+logs under persistent root-owned storage. The script must be idempotent and must:
+
+1. acquire a task-specific lock and record its trigger time and reason;
+2. preserve current bootloader, network, SSH, journal, and access-service state;
+3. restore or explicitly select the exact known-good stable boot entry and clear
+   any candidate one-shot entry using the detected bootloader's supported tools;
+4. sync persistent filesystems and request a normal system reboot;
+5. avoid deleting candidate artifacts, results, or unrelated configuration.
+
+Provide a non-mutating check mode and validate it before arming. Run the actual
+script only from a root-owned systemd service or equivalent scheduler. Never use
+an unqualified numeric boot-menu index or a script stored on tmpfs.
+
+Arm a one-shot pre-change timer with a generous deadline, normally at least 30
+minutes and longer than the bounded configuration window plus reconnect margin.
+Record its unit names, activation time, deadline, script/config hashes, status,
+and rollback log path. Confirm it remains armed from both SSH paths before each
+risky change. Do not perform long builds or benchmarks while this timer is armed.
+
+After each bounded change, verify direct SSH, reverse SSH, stable default, empty
+or expected one-shot state, watchdog, filesystems, services, and durable logs.
+Only then cancel the old timer. Arm a fresh timer before the next risky mutation;
+never extend a deadline blindly while either access path is unhealthy.
+
+## Candidate-Boot Bailout
+
+Prepare a separate boot-surviving bailout service/timer before selecting the
+candidate. It must activate only for the expected candidate kernel or explicit
+candidate boot token, wait long enough for boot and diagnosis, then select stable
+and reboot unless an authenticated post-boot health step disarms it. Verify that
+it will not fire on the stable kernel.
+
+Use a deadline comfortably longer than expected boot, SSH recovery, and health
+checks, but shorter than an unattended lockout; 20–30 minutes is a reasonable
+starting range, adjusted for the host. The bailout is not the benchmark timeout.
+Disarm it only after:
+
+- either direct or reverse access works and the second path's state is known;
+- candidate kernel identity, new boot ID, stable persistent default, filesystems,
+  storage, network, SSH, watchdog, services, and kernel logs pass health checks;
+- the controller has copied the post-boot evidence and explicitly records the
+  disarm action.
+
+If the candidate campaign will run longer than the bailout deadline, disarm the
+boot bailout after health validation and rely on the hardware watchdog, panic/oops
+reboot, and stable persistent default. Never leave a forgotten timer capable of
+rebooting during a benchmark.
+
+## Access-Loss Response
+
+If direct SSH fails, immediately try the already-tested reverse path and console
+or BMC; do not change routing or credentials speculatively. If reverse SSH fails,
+retain the direct session and diagnose the supervised service. If both fail, let
+the armed rollback/bailout and hardware watchdog act within their recorded
+deadlines. Avoid repeated power cycles or concurrent recovery commands.
+
+After recovery, verify the stable kernel and new boot ID, collect previous-boot
+journal/pstore/console logs and rollback evidence, classify the triggering change,
+and stop the candidate campaign until access safety is restored. Absence of a
+rollback log is not proof that the timer did not fire.

--- a/.agents/skills/csb-kernel-validate/references/boot-safety.md
+++ b/.agents/skills/csb-kernel-validate/references/boot-safety.md
@@ -5,6 +5,8 @@ Commands vary by distribution; inspect generated entries and vendor documentatio
 instead of assuming paths or menu titles.
 Complete the separate reboot-readiness probe and persist all campaign-critical
 volatile state before applying this boot procedure.
+Complete the access-safety gate, including direct and reverse SSH paths plus
+pre-change and candidate-boot rollback timers, before any mutation.
 
 ## Recovery Contract
 
@@ -89,6 +91,10 @@ Do not reboot until all checks pass:
 - stable is persistent default and candidate is one-shot;
 - panic/oops settings and available watchdog are verified;
 - SSH, console/BMC path, reconnect deadline, and recovery owner are recorded;
+- direct reconnecting SSH and the supervised reverse tunnel pass independent
+  end-to-end tests, with persistent logs and restricted credentials;
+- the current pre-change rollback and candidate-boot bailout states and deadlines
+  are verified from both access paths;
 - the volatile-state audit, persistent continuation manifest, off-host copy, and
   post-boot prerequisite probe have been verified;
 - build, install, bootloader, and preflight logs are durable off-host.

--- a/.agents/skills/csb-kernel-validate/references/boot-safety.md
+++ b/.agents/skills/csb-kernel-validate/references/boot-safety.md
@@ -7,6 +7,9 @@ Complete the separate reboot-readiness probe and persist all campaign-critical
 volatile state before applying this boot procedure.
 Complete the access-safety gate, including direct and reverse SSH paths plus
 pre-change and candidate-boot rollback timers, before any mutation.
+Complete [host-recovery-safety.md](host-recovery-safety.md), including proven
+out-of-band control, a boot-tested rescue environment, clean stable baseline
+boots, and verified snapshot/image recovery, before any mutation.
 
 ## Recovery Contract
 
@@ -17,7 +20,9 @@ Use all available layers:
 3. Configure reboot after panic/oops and preserve persistent kernel logs.
 4. Configure a hardware watchdog for a hard hang when `/dev/watchdog*` and a
    functioning watchdog driver exist.
-5. Prefer verified BMC, serial console, or local-console recovery.
+5. Require verified out-of-band console, power/reset, and recovery-media control.
+6. Require an independently bootable rescue environment and verified baseline
+   snapshot/image restoration path.
 
 One-shot booting makes the next reboot return to stable, but it cannot initiate a
 reboot from a hard lockup. Panic settings cannot recover a kernel that hangs before
@@ -75,6 +80,12 @@ non-destructive test procedure. Do not run a destructive watchdog test on a busy
 host. If no watchdog is available, retain one-shot fallback but label automatic
 hard-hang recovery unavailable.
 
+Provision watchdog policy separately on the stable host, activate it through a
+planned stable reboot, and load-test it before candidate installation. Never
+first-enable or shorten a watchdog in a candidate installer, and never combine
+watchdog changes with PID 1 re-execution. `systemctl daemon-reexec` and equivalent
+service-manager re-execution are prohibited during kernel validation.
+
 Use pstore/ramoops, a serial console, netconsole, or persistent journal when
 available. Verify logs survive reboot before the experiment. Never treat absent
 logs as evidence that no panic occurred.
@@ -91,6 +102,11 @@ Do not reboot until all checks pass:
 - stable is persistent default and candidate is one-shot;
 - panic/oops settings and available watchdog are verified;
 - SSH, console/BMC path, reconnect deadline, and recovery owner are recorded;
+- out-of-band console/power/recovery-media controls and external console logging
+  have been tested;
+- the independent rescue environment has been booted and used to copy read-only
+  evidence off-host;
+- a current verified baseline snapshot/image and restoration procedure exist;
 - direct reconnecting SSH and the supervised reverse tunnel pass independent
   end-to-end tests, with persistent logs and restricted credentials;
 - the current pre-change rollback and candidate-boot bailout states and deadlines

--- a/.agents/skills/csb-kernel-validate/references/boot-safety.md
+++ b/.agents/skills/csb-kernel-validate/references/boot-safety.md
@@ -1,0 +1,106 @@
+# Remote Kernel Boot Safety
+
+Read this entire reference before installing or booting a candidate kernel.
+Commands vary by distribution; inspect generated entries and vendor documentation
+instead of assuming paths or menu titles.
+Complete the separate reboot-readiness probe and persist all campaign-critical
+volatile state before applying this boot procedure.
+
+## Recovery Contract
+
+Use all available layers:
+
+1. Keep the known-good kernel installed and configured as the persistent default.
+2. Select the candidate with a one-shot boot entry only.
+3. Configure reboot after panic/oops and preserve persistent kernel logs.
+4. Configure a hardware watchdog for a hard hang when `/dev/watchdog*` and a
+   functioning watchdog driver exist.
+5. Prefer verified BMC, serial console, or local-console recovery.
+
+One-shot booting makes the next reboot return to stable, but it cannot initiate a
+reboot from a hard lockup. Panic settings cannot recover a kernel that hangs before
+they take effect. Without a tested watchdog or an operator/BMC power cycle, report
+that hard-hang recovery is not guaranteed.
+
+## Inventory Before Mutation
+
+Capture at least:
+
+```text
+uname -a; cat /proc/cmdline; cat /etc/os-release
+findmnt / /boot /boot/efi; df -h /boot /boot/efi
+ls -l /boot; ls /lib/modules
+bootctl status                 # when systemd-boot is present
+grub-editenv list              # when GRUB is present
+efibootmgr -v                  # on EFI, when available
+systemctl status systemd-pstore
+ls -l /dev/watchdog*; wdctl
+journalctl -k -b; dmesg
+```
+
+Also record the stable entry identifier, kernel/initramfs/module hashes, current
+boot ID, root device/filesystem, storage health indicators, and whether the stable
+kernel has been boot-tested recently.
+
+## One-Shot Selection
+
+- **GRUB:** keep the stable entry as the configured default and use the
+  distribution-supported `grub-reboot`/`next_entry` mechanism for the candidate.
+  Inspect `grubenv` and generated menu entries before reboot. Do not rely on a
+  guessed numeric index; submenu ordering changes after kernel installation.
+- **systemd-boot:** keep the stable default and use `bootctl set-oneshot` with the
+  exact candidate entry. Inspect `bootctl list` and `bootctl status` afterward.
+  Use boot counting only when the installed system is already configured for it
+  and its behavior has been verified.
+- **extlinux/U-Boot/vendor loaders:** require a documented, testable one-shot or
+  boot-count fallback. If only a permanent default can be changed, stop unless
+  an operator-controlled console/BMC recovery plan is explicitly authorized.
+
+After selection, prove both facts independently: candidate is next boot only, and
+stable remains the persistent default after that attempt.
+
+## Fatal-Error Reboot
+
+Use distribution-supported persistent sysctl or kernel command-line settings for
+nonzero `kernel.panic` and `kernel.panic_on_oops=1`. Consider lockup/NMI panic
+settings only when supported and appropriate for the architecture and workload;
+they can create false positives during extreme benchmark oversubscription. Record
+every change and its rollback.
+
+For hard hangs, configure the existing watchdog stack rather than inventing one.
+Verify the watchdog device, timeout, daemon/systemd ownership, and an accepted
+non-destructive test procedure. Do not run a destructive watchdog test on a busy
+host. If no watchdog is available, retain one-shot fallback but label automatic
+hard-hang recovery unavailable.
+
+Use pstore/ramoops, a serial console, netconsole, or persistent journal when
+available. Verify logs survive reboot before the experiment. Never treat absent
+logs as evidence that no panic occurred.
+
+## Pre-Reboot Gate
+
+Do not reboot until all checks pass:
+
+- unrelated work is absent and reboot authorization is in scope;
+- stable image, initramfs, modules, and boot entry remain intact;
+- candidate image, initramfs, modules, release string, and root/network drivers
+  match;
+- boot and root filesystems are healthy and have adequate free space;
+- stable is persistent default and candidate is one-shot;
+- panic/oops settings and available watchdog are verified;
+- SSH, console/BMC path, reconnect deadline, and recovery owner are recorded;
+- the volatile-state audit, persistent continuation manifest, off-host copy, and
+  post-boot prerequisite probe have been verified;
+- build, install, bootloader, and preflight logs are durable off-host.
+
+## Post-Boot Classification
+
+Classify the attempt as successful only after kernel identity and health checks.
+If the host returns on stable instead of candidate, recovery may have worked but
+the candidate boot failed; collect previous-boot journal, pstore, bootloader boot
+count/status, and console/BMC evidence. If the host is unreachable beyond the
+declared deadline, use the authorized recovery channel and stop benchmark work.
+
+Filesystem corruption, I/O errors, oops/panic, hung-task storms, watchdog resets,
+unexpected boot IDs, missing devices, degraded arrays, failed mounts, or critical
+service failures reject the candidate even if CSB performance improves.

--- a/.agents/skills/csb-kernel-validate/references/host-recovery-safety.md
+++ b/.agents/skills/csb-kernel-validate/references/host-recovery-safety.md
@@ -1,0 +1,165 @@
+# Host-Independent Recovery Safety
+
+Complete this entire gate before the first mutation of a remote Linux host for
+kernel validation. It applies across distributions, architectures, bootloaders,
+storage layouts, virtualization platforms, and physical machines. Read-only
+inventory and non-mutating probes are allowed before the gate. Package
+installation, kernel or module installation, network or SSH changes, bootloader
+changes, snapshot creation, watchdog or panic configuration, service-manager
+reload/re-execution, and reboot are mutations and must wait.
+
+## Contents
+
+- [Hard Stop Conditions](#hard-stop-conditions)
+- [Out-of-Band Recovery](#out-of-band-recovery)
+- [Independent Rescue Environment](#independent-rescue-environment)
+- [Stable Baseline, Backup, and Snapshot](#stable-baseline-backup-and-snapshot)
+- [Mutation Boundary](#mutation-boundary)
+- [Watchdog and Fatal-Error Policy](#watchdog-and-fatal-error-policy)
+- [Recovery Layers and Limits](#recovery-layers-and-limits)
+- [Before-Mutation Evidence](#before-mutation-evidence)
+
+## Hard Stop Conditions
+
+Do not mutate the host unless all of these are proven:
+
+1. an authenticated out-of-band recovery operator can observe the console,
+   control power/reset, and select or attach recovery boot media without relying
+   on the installed operating system;
+2. a boot-tested rescue environment can start independently of the normal root
+   filesystem and provides storage, volume, filesystem, bootloader, network,
+   SSH, journal, and copy-out tools needed for that host;
+3. the known-good stable kernel and a tested stable userspace boot remain the
+   persistent default;
+4. a verified baseline backup or revertible snapshot exists, with its restore
+   procedure and prerequisites copied off-host;
+5. direct SSH, a separately routed or reverse SSH path, and the out-of-band
+   console work concurrently and have independently recorded identities;
+6. off-host copies contain the recovery manifest, boot/storage inventory,
+   artifact hashes, rollback commands, and credentials-location metadata;
+7. task-specific pre-change rollback and candidate-boot bailout mechanisms pass
+   non-mutating checks and do not represent OS-level recovery as sufficient for
+   failures that occur before init.
+
+If the platform cannot provide a required layer, stop and classify validation as
+blocked. Authorization to reboot does not waive recovery readiness.
+
+## Out-of-Band Recovery
+
+Use a dedicated BMC, service processor, hypervisor console, cloud serial console
+plus rescue controls, or an equivalent management plane isolated from the
+workload OS. Verify, rather than assume:
+
+- console input and externally persisted output;
+- power status, reset/power-cycle controls, and audit timestamps;
+- firmware/boot-menu control or virtual-media attachment;
+- host identity and management-plane access after the workload network is down;
+- restricted credentials, ownership, and a named recovery operator;
+- a documented recovery-media boot sequence that does not overwrite disks.
+
+Continuously capture console output off-host for every install and boot attempt.
+Do not expose management interfaces publicly or weaken their authentication.
+
+## Independent Rescue Environment
+
+Provide a small recovery OS or self-contained recovery initramfs on separate
+media, a separate disk/partition, immutable network boot, or management-plane
+virtual media. It must not require the normal root filesystem, its dynamic
+loader, its system manager, or the candidate kernel. Include the tools needed for
+the actual storage stack, such as LVM, RAID, encryption, filesystem checking,
+bootloader repair, initramfs inspection, storage-health queries, networking,
+restricted SSH, checksumming, and evidence copy-out.
+
+Boot the rescue environment before validation, verify its console and restricted
+SSH access, activate the real storage without modifying it, mount the root
+read-only, and demonstrate that logs and selected evidence can be copied to the
+controller. Record its image hash, boot entry/media, network identity, unlock
+requirements without secret contents, and exact recovery commands.
+
+## Stable Baseline, Backup, and Snapshot
+
+Before validation, require at least two clean stable boots with distinct boot
+IDs and successful post-boot health probes. Record stable kernel, initramfs,
+modules, root filesystem, loader/interpreter, bootloader, storage topology, and
+service-manager identities and hashes where practical.
+
+Create and verify an off-host baseline sufficient to recover:
+
+- partition/GPT and EFI/boot metadata;
+- bootloader configuration and environment;
+- stable kernel, initramfs, configuration, symbols, and module tree;
+- root-volume and volume-manager metadata;
+- critical system-manager, SSH, network, and early-boot configuration;
+- recovery media, continuation manifest, and restoration procedure.
+
+Use a native snapshot or image rollback when the platform supports one. Record
+capacity, consistency point, identifier, parent, expiry, and restore procedure.
+Never call a file copy of a live root filesystem an atomic snapshot. If a safe
+snapshot or restorable image cannot be made and verified, stop.
+
+## Mutation Boundary
+
+Separate host provisioning from each candidate installation.
+
+Provision and prove access, recovery, persistent logging, watchdog ownership,
+panic policy, and rescue boot while running the stable system. Apply changes
+through their normal boot-time activation path and complete a clean stable reboot
+plus health audit before candidate work. Never first-enable or shorten a
+watchdog, change panic policy, reconfigure SSH/networking, or re-execute the
+service manager as part of a candidate installer.
+
+Candidate installation may write only uniquely named candidate artifacts and
+the exact bootloader data needed to register them. It must not replace stable
+artifacts, mutate unrelated root files, change the persistent default, or combine
+installation with reboot. Prefer distribution-native signed packages. If an
+archive is unavoidable, reject absolute paths, traversal, escaping symlinks,
+unexpected top-level paths, duplicate paths, devices, FIFOs, and writes outside
+the unique candidate module tree before extraction. Extract to a staging root,
+compare the resulting inventory, then install explicitly.
+
+Prohibit service-manager re-execution (`systemctl daemon-reexec` or equivalent)
+during kernel validation. Ordinary unit-file changes, when separately
+authorized, may use the least disruptive supported reload only after proving it
+does not re-execute PID 1; otherwise defer activation to a planned stable boot.
+
+## Watchdog and Fatal-Error Policy
+
+Configure a hardware or platform watchdog only during stable-host provisioning.
+Identify its owner, device, timeout limits, pretimeout behavior, reset-cause
+evidence, and interaction with firmware and the service manager. Start with a
+generous timeout that exceeds worst-case stable boot and maximum validated host
+load with margin; do not default to a short timeout. Test configuration parsing
+non-destructively, activate it through a planned stable reboot, then prove the
+stable system services it under representative maximum load.
+
+Never dynamically enable or shorten a watchdog immediately before PID 1 reload,
+re-execution, package installation, initramfs generation, bootloader writes, or
+other unbounded operations. Do not use watchdog expiry as the only rollback
+mechanism. Prefer candidate-specific panic/oops command-line arguments over live
+global sysctl changes, and verify persistent crash/reset evidence through serial
+console, pstore/ramoops, firmware logs, or equivalent facilities.
+
+## Recovery Layers and Limits
+
+Use all layers, recognizing their boundaries:
+
+1. direct SSH reconnect protects against a dropped client connection;
+2. reverse or separately routed SSH protects against one ingress path failing;
+3. a pre-change rollback timer protects while stable userspace works;
+4. a candidate bailout protects after candidate userspace starts;
+5. one-shot boot plus stable persistent default protects the next boot attempt;
+6. watchdog and panic reboot protect some hangs and crashes;
+7. out-of-band control plus independent rescue protects early-boot, root-mount,
+   loader, PID 1, network, and repeated stable-boot failures;
+8. verified snapshot/image restoration protects persistent-system corruption.
+
+No SSH tunnel or systemd timer can recover a host that cannot execute init. No
+one-shot candidate fallback repairs a damaged stable root filesystem. Do not
+represent a higher layer as covered by a lower one.
+
+## Before-Mutation Evidence
+
+Create a checksummed gate record containing pass/fail and evidence paths for
+every item above. Copy it to the controller and verify the destination hash.
+Record the exact first authorized mutation and require it to match the reviewed
+command. Any missing, stale, contradictory, or untested item is a stop.

--- a/.agents/skills/csb-kernel-validate/references/reboot-readiness.md
+++ b/.agents/skills/csb-kernel-validate/references/reboot-readiness.md
@@ -5,6 +5,10 @@ remote machine before building and immediately before every reboot. Store the
 probe, continuation manifest, and critical state on persistent remote storage and
 copy them to the controller.
 
+Complete [host-recovery-safety.md](host-recovery-safety.md) before any host
+mutation. Reboot readiness supplements, rather than replaces, its mandatory
+out-of-band, rescue-boot, stable-baseline, and snapshot/image recovery gates.
+
 ## Machine and Boot Prerequisites
 
 Record and verify:
@@ -18,6 +22,10 @@ Record and verify:
 - bootloader entries/default/one-shot support, stable kernel artifacts, console
   or BMC, watchdog, persistent journal/pstore, SSH/network startup, DNS/routes,
   firewall, and time synchronization;
+- externally logged out-of-band console, power/reset, firmware boot selection,
+  recovery media, independent rescue OS/initramfs, and named recovery operator;
+- baseline image or native snapshot identity, consistency point, capacity,
+  expiry, off-host metadata, and tested restoration procedure;
 - direct and reverse SSH endpoints, host keys, restricted credentials, supervised
   service ordering/restart behavior, allocated reverse port, and persistent logs;
 - CSB checkout and submodule commits/dirty state, configs, generated headers,
@@ -30,6 +38,11 @@ Check that boot-critical drivers are built in or present in the candidate
 initramfs. Verify the initramfs contains the required root-storage, filesystem,
 encryption, RAID/LVM, network, and console support. Use distribution tools to
 inspect it; do not infer contents from the build config alone.
+
+Require two clean stable boots and a successful rescue-environment boot before
+the first candidate series. Verify that rescue can activate the actual storage
+stack, mount the normal root read-only, inspect initramfs/bootloader/journal, and
+copy evidence to the controller without depending on the normal userspace.
 
 ## Volatile-State Audit
 

--- a/.agents/skills/csb-kernel-validate/references/reboot-readiness.md
+++ b/.agents/skills/csb-kernel-validate/references/reboot-readiness.md
@@ -18,6 +18,8 @@ Record and verify:
 - bootloader entries/default/one-shot support, stable kernel artifacts, console
   or BMC, watchdog, persistent journal/pstore, SSH/network startup, DNS/routes,
   firewall, and time synchronization;
+- direct and reverse SSH endpoints, host keys, restricted credentials, supervised
+  service ordering/restart behavior, allocated reverse port, and persistent logs;
 - CSB checkout and submodule commits/dirty state, configs, generated headers,
   benchmark executables, runtime images/rootfs, Python environment, kernel source,
   patch, build config, toolchain, packages, sudo rights, and monitor tools;
@@ -75,6 +77,8 @@ Create a continuation manifest containing:
   monitor preparation that must be reconstructed after boot;
 - an idempotent post-boot probe, setup sequence, continuation command, expected
   process/session names, validation commands, rollback commands, and stop gates.
+- exact direct/reverse SSH verification commands plus pre-change rollback and
+  candidate-boot bailout unit names, deadlines, hashes, logs, and disarm rules.
 
 Copy the manifest and irreplaceable evidence to the controller before reboot.
 Verify checksums at the destination. Never move credentials to the controller or
@@ -93,6 +97,7 @@ Do not configure automatic benchmark execution at boot. First require SSH or
 console reconnection, candidate-kernel identity and health verification, stable
 fallback verification, and prerequisite parity. Automation may start only an
 idempotent probe that records readiness without mutating benchmark results.
+Test both SSH paths and timed rollback in non-mutating/check mode before reboot.
 
 ## Post-Boot Parity Gate
 

--- a/.agents/skills/csb-kernel-validate/references/reboot-readiness.md
+++ b/.agents/skills/csb-kernel-validate/references/reboot-readiness.md
@@ -1,0 +1,112 @@
+# Remote Reboot Readiness
+
+Treat reboot survival as a prerequisite, not a cleanup detail. Probe the actual
+remote machine before building and immediately before every reboot. Store the
+probe, continuation manifest, and critical state on persistent remote storage and
+copy them to the controller.
+
+## Machine and Boot Prerequisites
+
+Record and verify:
+
+- architecture, CPU topology, memory, firmware/microcode, clock source, NUMA,
+  kernel config, compiler/toolchain, required kernel modules, and initramfs tools;
+- root, boot, EFI, data, network, and remote filesystems plus UUID/PARTUUID/LVM,
+  RAID, encryption, and mount dependencies needed during early boot;
+- free space and inodes for source, build, modules, initramfs, `/boot`, logs, and
+  every result repetition;
+- bootloader entries/default/one-shot support, stable kernel artifacts, console
+  or BMC, watchdog, persistent journal/pstore, SSH/network startup, DNS/routes,
+  firewall, and time synchronization;
+- CSB checkout and submodule commits/dirty state, configs, generated headers,
+  benchmark executables, runtime images/rootfs, Python environment, kernel source,
+  patch, build config, toolchain, packages, sudo rights, and monitor tools;
+- Docker/containerd/runc/youki/bwrap, cgroups, tracefs/debugfs, perf permissions,
+  BPF, sysstat, required services, devices, NICs, storage, and benchmark datasets.
+
+Check that boot-critical drivers are built in or present in the candidate
+initramfs. Verify the initramfs contains the required root-storage, filesystem,
+encryption, RAID/LVM, network, and console support. Use distribution tools to
+inspect it; do not infer contents from the build config alone.
+
+## Volatile-State Audit
+
+Enumerate mounts and filesystem types with `findmnt`, paying particular attention
+to tmpfs/ramfs and ephemeral or network-backed paths. At minimum inspect `/tmp`,
+`/var/tmp`, `/run`, `/dev/shm`, user runtime directories, container runtime state,
+tmux sockets, build/output directories, result paths, monitor scratch paths, and
+task-specific environment variables.
+
+Search running campaign processes for dependencies on volatile or deleted files:
+
+```text
+process command, cwd, root, executable, open file descriptors
+tmux/systemd session command and working directory
+temporary configs, generated headers, FIFOs, sockets, lock/barrier files
+virtual environments, compiler caches, source/build trees, datasets and rootfs
+perf.data, traces, monitor output, journals, ledgers, logs and partial results
+SSH agents/control sockets, credentials, tokens and configuration paths
+```
+
+Do not print secret contents. Record only the protected persistent location and
+required ownership/mode. Treat `/tmp` as volatile even when it currently resides
+on disk; cleanup policy may remove it during boot. Treat `/var/tmp` as persistent
+only after verifying the distribution's mount and cleanup policy.
+
+## Persist Campaign State
+
+Stop at a clean stage boundary. Do not checkpoint an actively writing benchmark
+by copying its directory and calling it resumable. Flush and close task-owned
+writers, then copy every required input and completed artifact to a dedicated
+persistent directory outside tmpfs. Preserve ownership, modes, timestamps, links,
+xattrs, ACLs, sparse files, and checksums when relevant. Keep unrelated files and
+processes untouched.
+
+Create a continuation manifest containing:
+
+- campaign/task ID, host, stable and candidate kernel identities, boot ID, CSB
+  and submodule commits, dirty-state patch/status, source/config/patch hashes;
+- durable absolute paths for configs, headers, binaries, datasets, images/rootfs,
+  build artifacts, logs, results, stage ledger, and recovery evidence;
+- exact completed, failed, active, and pending stages based on result/log/exit
+  evidence rather than `.done` markers alone;
+- required mounts, services, modules, sysctls, cgroups, runtime state, permissions,
+  CPU/frequency/IRQ/NUMA policy, hugepages, NIC/storage tuning, environment, and
+  monitor preparation that must be reconstructed after boot;
+- an idempotent post-boot probe, setup sequence, continuation command, expected
+  process/session names, validation commands, rollback commands, and stop gates.
+
+Copy the manifest and irreplaceable evidence to the controller before reboot.
+Verify checksums at the destination. Never move credentials to the controller or
+another location unless authorized; instead ensure their normal protected source
+will exist after boot.
+
+## Continuation Dry Run
+
+Before reboot, execute the post-boot prerequisite probe without changing the
+kernel and validate that it identifies the current healthy host. Validate the
+continuation command in a no-op, list, dry-run, or narrowly scoped wiring mode when
+supported. Confirm it references only persistent paths and can recreate its tmux
+or systemd-run session without inherited shell state.
+
+Do not configure automatic benchmark execution at boot. First require SSH or
+console reconnection, candidate-kernel identity and health verification, stable
+fallback verification, and prerequisite parity. Automation may start only an
+idempotent probe that records readiness without mutating benchmark results.
+
+## Post-Boot Parity Gate
+
+After reconnecting, compare the new probe with the pre-reboot manifest. Verify:
+
+- expected kernel/build ID and new boot ID, with no intervening unexplained boot;
+- all required local/remote filesystems, storage, NICs, services, runtimes,
+  devices, modules, cgroups, tracefs/debugfs, perf/BPF permissions, and time sync;
+- persistent files and checksums, CSB/source commits, configs, headers, binaries,
+  datasets, images, Python/toolchain versions, free space, and ownership/modes;
+- restored CPU/frequency/IRQ/NUMA, hugepage, sysctl, monitor, and runtime setup;
+- absence of oops, panic, watchdog reset, filesystem/I/O errors, degraded storage,
+  failed units, stale workload processes, or partial campaign writers.
+
+Resume only from the last evidenced clean stage. If parity cannot be restored,
+classify the attempt as blocked or failed and preserve diagnostics; do not weaken
+the benchmark or silently regenerate missing inputs because tmpfs was cleared.


### PR DESCRIPTION
Add

- add the `csb-kernel-validate` project skill;
- add one-shot boot and stable-kernel recovery guidance;
- add remote reboot-readiness and volatile-state checks;
- add direct and reverse SSH recovery paths;
- add pre-change rollback and candidate-boot bailout timers;
- add mandatory out-of-band and rescue-environment recovery gates;
- add baseline snapshot/image restoration requirements;
- add repeated stable/patched CSB comparison gates.

Note

- compose `csb-analysis`, `csb-refine`, `csb-remote`, and `csb`;
- keep the stable kernel as the persistent boot default;
- require campaign-critical tmpfs state to be persisted before reboot;
- require two clean stable boots before candidate validation;
- restrict and independently test SSH and out-of-band recovery paths;
- prohibit PID 1 re-execution during kernel validation;
- provision and load-test watchdog policy on the stable kernel;
- reject unsafe, incorrect, or unmeasurable kernel patch candidates.

Validation

- `quick_validate.py .agents/skills/csb-kernel-validate`
- `git diff --check`
- local and PR skill directories compared byte-for-byte
