### PR TITLE
Fix segfault in min_mysql_lseek_fcntl_9_0

### DIFF
--- a/bench/targets/mysql/syz/min_mysql_lseek_fcntl_9_0.h
+++ b/bench/targets/mysql/syz/min_mysql_lseek_fcntl_9_0.h
@@ -8,7 +8,7 @@
 #define CSB_PROGRAM_NAME ""
 #endif
 #define MMAP_OFFSET 0x20000000ul
-#define MMAP_LENGTH 0x1000000ul
+#define MMAP_LENGTH 0x1161000ul
 const static uint64_t maxWriteBufferSize = 0ul;
 const static uint64_t maxWriteBufferSizeAlignment = 4096ul;
 static const char* netops_connect[0] __attribute__((unused)) = {};


### PR DESCRIPTION
Other autogenerated benchmarks are unaffected. Update submodule accordingly.