### PR TITLE
Add stress-ng scalability examples

### DIFF
--- a/bm-runner/tests/test_stress_ng_adapter.py
+++ b/bm-runner/tests/test_stress_ng_adapter.py
@@ -1,0 +1,33 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+from pathlib import Path
+
+
+ADAPTER = Path(__file__).parents[2] / "scripts/adapters/stress-ng-adapter.sh"
+
+
+def test_stress_ng_adapter_parses_summary_and_pthread_metrics():
+    output = """\
+stress-ng: metrc: [1] stressor bogo ops real time usr time sys time bogo ops/s
+stress-ng: metrc: [1] pthread 2812 1.00 0.23 0.52 2809.25 3731.35 75.29 4204
+stress-ng: metrc: [1] miscellaneous metrics:
+stress-ng: metrc: [1] pthread 27946.62 nanosecs to start a pthread
+stress-ng: metrc: [1] pthread 100.00 % of 128 pthreads created
+stress-ng: info: [1] skipped: 0
+stress-ng: info: [1] passed: 1: pthread (1)
+stress-ng: info: [1] failed: 0
+stress-ng: info: [1] metrics untrustworthy: 0
+"""
+
+    result = subprocess.run([ADAPTER], input=output, text=True, capture_output=True, check=True)
+
+    assert "stressor=pthread;" in result.stdout
+    assert "ops=2812;" in result.stdout
+    assert "throughput_real=2809.25;" in result.stdout
+    assert "pthread_start_ns=27946.62;" in result.stdout
+    assert "pthread_created_percent=100.00;" in result.stdout
+    assert "passed=1;" in result.stdout
+    assert "failed=0;" in result.stdout
+    assert "untrustworthy=0;" in result.stdout

--- a/config/bm-external/stress-ng/exec.json
+++ b/config/bm-external/stress-ng/exec.json
@@ -1,0 +1,56 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#stress-ng exec workers",
+      "y": "throughput_real",
+      "y_lbl": "Exec bogo operations/s",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "stress-ng execve throughput"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "scripts/bm-external",
+      "name": "stress-ng.sh",
+      "args": "--exec {threads} --exec-max 128 --exec-method execve --exec-fork-method fork --timeout {duration}s --metrics --verify",
+      "adapter": {
+        "name": "stress-ng-adapter.sh"
+      }
+    }
+  ]
+}

--- a/config/bm-external/stress-ng/prctl.json
+++ b/config/bm-external/stress-ng/prctl.json
@@ -1,0 +1,56 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#stress-ng prctl workers",
+      "y": "throughput_real",
+      "y_lbl": "prctl bogo operations/s",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "stress-ng prctl throughput"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "scripts/bm-external",
+      "name": "stress-ng.sh",
+      "args": "--prctl {threads} --timeout {duration}s --metrics --verify",
+      "adapter": {
+        "name": "stress-ng-adapter.sh"
+      }
+    }
+  ]
+}

--- a/config/bm-external/stress-ng/pthread.json
+++ b/config/bm-external/stress-ng/pthread.json
@@ -1,0 +1,66 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#stress-ng pthread workers",
+      "y": "throughput_real",
+      "y_lbl": "Pthread bogo operations/s",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "stress-ng pthread throughput"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "#stress-ng pthread workers",
+      "y": "pthread_start_ns",
+      "y_lbl": "pthread start time (ns)",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "stress-ng pthread creation latency"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "scripts/bm-external",
+      "name": "stress-ng.sh",
+      "args": "--pthread {threads} --pthread-max 128 --timeout {duration}s --metrics --verify",
+      "adapter": {
+        "name": "stress-ng-adapter.sh"
+      }
+    }
+  ]
+}

--- a/doc/bm-external/stress-ng.md
+++ b/doc/bm-external/stress-ng.md
@@ -1,0 +1,34 @@
+# Using stress-ng
+
+Install `stress-ng` with the host package manager. CSB provides native
+scalability examples for kernel paths exercised by the `exec`, `pthread`, and
+`prctl` stressors:
+
+```bash
+sudo scripts/run-single.sh config/bm-external/stress-ng/exec.json
+sudo scripts/run-single.sh config/bm-external/stress-ng/pthread.json
+sudo scripts/run-single.sh config/bm-external/stress-ng/prctl.json
+```
+
+The examples deliberately use one CSB execution unit and vary stress-ng's
+worker count. This keeps all workers in one host workload while CSB records the
+worker count as `nb_threads`. The execution unit is assigned eight physical
+cores. Adjust `core_count` and the thread list together when testing a larger
+machine.
+
+stress-ng refuses to run its `exec` stressor as root. If CSB was started with
+`sudo`, the wrapper runs stress-ng as `SUDO_UID`/`SUDO_GID`; otherwise it keeps
+the current user. The wrapper also merges stress-ng's stderr metrics into the
+stream consumed by the CSB adapter.
+
+The `exec` example retains stress-ng's pthread launcher and forces `fork` plus
+`execve`. The `pthread` example records both throughput and stress-ng's
+pthread-start latency. The `prctl` stressor includes many prctl operations, so
+its aggregate throughput is only useful when a profile confirms that the
+kernel path under investigation is material.
+
+The committed settings are short functional examples. For performance claims,
+increase `duration`, set `repeat` to at least five, include the target high
+worker counts, stabilize CPU frequency, and report every repetition and
+failure counter. stress-ng metrics are supporting evidence rather than a
+substitute for a focused reproducer and matching kernel profile.

--- a/doc/bm-runner.md
+++ b/doc/bm-runner.md
@@ -157,6 +157,8 @@ to add external benchmarks under the following conditions:
 
 CSB contains minimal examples for some external benchmarks like [fio][], [stress-ng][], [unixbench][], and [will-it-scale][].
 Each of these benchmarks have a JSON file under `config/` and an adapter under `scripts/adapters`.
+See [Using stress-ng](bm-external/stress-ng.md) for focused scalability
+examples and validation guidance.
 For [unixbench][] and [will-it-scale][] we recommend users to clone these repos under a folder called `bm-external` inside
 `CSB` directory.
 

--- a/scripts/adapters/stress-ng-adapter.sh
+++ b/scripts/adapters/stress-ng-adapter.sh
@@ -2,10 +2,51 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-awk '/stress-ng: metrc:/ {
-    count++;
-    if (count == 3) {
-        printf "stressor=%s;ops=%s;real_time=%s;usr_time=%s;sys_time=%s;throughput_real=%s;throughput_cpus=%s;cpu_percent=%s;rss_max=%s;\n",
-               $4, $5, $6, $7, $8, $9, $10, $11, $12
-    }
+awk '
+/stress-ng: metr(c|ic):/ && $5 ~ /^[0-9]+([.][0-9]+)?$/ && $6 ~ /^[0-9]+([.][0-9]+)?$/ {
+    if ($6 == "nanosecs" || $6 == "%")
+        next
+    stressor = $4
+    ops = $5
+    real_time = $6
+    usr_time = $7
+    sys_time = $8
+    throughput_real = $9
+    throughput_cpus = $10
+    cpu_percent = $11
+    rss_max = $12
+}
+/stress-ng: metr(c|ic):/ && $6 == "nanosecs" {
+    pthread_start_ns = $5
+}
+/stress-ng: metr(c|ic):/ && $6 == "%" {
+    pthread_created_percent = $5
+}
+/stress-ng: info:/ && $4 == "skipped:" {
+    skipped = $5
+    sub(/:$/, "", skipped)
+}
+/stress-ng: info:/ && $4 == "passed:" {
+    passed = $5
+    sub(/:$/, "", passed)
+}
+/stress-ng: info:/ && $4 == "failed:" {
+    failed = $5
+    sub(/:$/, "", failed)
+}
+/stress-ng: info:/ && $4 == "metrics" && $5 == "untrustworthy:" {
+    untrustworthy = $6
+}
+END {
+    if (stressor == "")
+        exit 1
+    printf "stressor=%s;ops=%s;real_time=%s;usr_time=%s;sys_time=%s;throughput_real=%s;throughput_cpus=%s;cpu_percent=%s;rss_max=%s;skipped=%s;passed=%s;failed=%s;untrustworthy=%s;",
+           stressor, ops, real_time, usr_time, sys_time, throughput_real,
+           throughput_cpus, cpu_percent, rss_max, skipped, passed, failed,
+           untrustworthy
+    if (pthread_start_ns != "")
+        printf "pthread_start_ns=%s;", pthread_start_ns
+    if (pthread_created_percent != "")
+        printf "pthread_created_percent=%s;", pthread_created_percent
+    printf "\n"
 }'

--- a/scripts/bm-external/stress-ng.sh
+++ b/scripts/bm-external/stress-ng.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# stress-ng's exec stressor refuses to run as root. CSB may itself be launched
+# with sudo for Docker access, so return to the invoking user for the workload.
+if [[ $(id -u) -eq 0 && -n ${SUDO_UID:-} && ${SUDO_UID} -ne 0 ]]; then
+    exec setpriv --reuid="${SUDO_UID}" --regid="${SUDO_GID}" --init-groups \
+        stress-ng "$@" 2>&1
+fi
+
+# stress-ng writes its metrics to stderr. Merge both streams so CSB's adapter
+# receives the metric table for native runs as well as container runs.
+exec stress-ng "$@" 2>&1


### PR DESCRIPTION
## Add

- focused stress-ng exec, pthread, and prctl scalability configs
- a wrapper that preserves metrics and handles sudo execution safely
- adapter regression coverage and benchmark guidance

## Change

- parse current and legacy stress-ng metric labels
- expose failure counts and pthread creation metrics

## Fix

- allow the exec stressor to run as the invoking non-root user

## Note

- focused adapter test passes
- all three configs passed through `scripts/run-single.sh` locally at
  1, 2, 4, and 8 workers with zero stress-ng failures
- the broader Python suite has unrelated Docker-socket and mocked-topology
  failures on this host
