### PR TITLE
Add fio scalability examples

### DIFF
--- a/bm-runner/tests/test_fio_json_adapter.py
+++ b/bm-runner/tests/test_fio_json_adapter.py
@@ -1,0 +1,48 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ADAPTER = Path(__file__).parents[2] / "scripts/adapters/fio-json-adapter.py"
+
+
+def test_fio_json_adapter_parses_io_and_latency_metrics():
+    document = {
+        "jobs": [
+            {
+                "error": 0,
+                "job_runtime": 3000,
+                "usr_cpu": 1.2,
+                "sys_cpu": 8.4,
+                "read": {
+                    "iops": 123.5,
+                    "bw": 494,
+                    "total_ios": 371,
+                    "clat_ns": {
+                        "percentile": {
+                            "50.000000": 1000,
+                            "95.000000": 2000,
+                            "99.000000": 3000,
+                            "99.900000": 4000,
+                        }
+                    },
+                },
+                "write": {"iops": 0, "bw": 0, "total_ios": 0},
+            }
+        ]
+    }
+    result = subprocess.run(
+        [ADAPTER],
+        input=json.dumps(document),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "error=0;" in result.stdout
+    assert "read_iops=123.5;" in result.stdout
+    assert "read_clat_p99_9_ns=4000;" in result.stdout
+    assert "write_iops=0;" in result.stdout

--- a/config/bm-external/fio/lru-buffered-read.json
+++ b/config/bm-external/fio/lru-buffered-read.json
@@ -1,0 +1,66 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#fio jobs",
+      "y": "read_bw",
+      "y_lbl": "Read bandwidth (KiB/s)",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "fio buffered-read throughput"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "#fio jobs",
+      "y": "read_clat_p99_ns",
+      "y_lbl": "Read p99 latency (ns)",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "fio buffered-read p99 latency"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "scripts/bm-external",
+      "name": "fio.sh",
+      "args": "--name=lru-buffered-read --size=256m --rw=read --bs=128k --ioengine=psync --direct=0 --invalidate=1 --fadvise_hint=1 --numjobs={threads} --time_based=1 --runtime={duration} --group_reporting=1 --lat_percentiles=1 --percentile_list=50:95:99:99.9 --output-format=json",
+      "adapter": {
+        "name": "fio-json-adapter.py"
+      }
+    }
+  ]
+}

--- a/config/bm-external/fio/mq-deadline.json
+++ b/config/bm-external/fio/mq-deadline.json
@@ -1,0 +1,66 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#fio jobs",
+      "y": "read_iops",
+      "y_lbl": "Read IOPS",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "fio mq-deadline read IOPS"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "#fio jobs",
+      "y": "read_clat_p99_9_ns",
+      "y_lbl": "Read p99.9 latency (ns)",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "fio mq-deadline p99.9 latency"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "scripts/bm-external",
+      "name": "fio.sh",
+      "args": "--name=mq-deadline-contention --rw=randrw --rwmixread=50 --bs=4k --ioengine=psync --direct=1 --numjobs={threads} --size=64m --time_based=1 --runtime={duration} --fsync=128 --group_reporting=1 --lat_percentiles=1 --percentile_list=50:95:99:99.9 --output-format=json",
+      "adapter": {
+        "name": "fio-json-adapter.py"
+      }
+    }
+  ]
+}

--- a/doc/bm-external/fio.md
+++ b/doc/bm-external/fio.md
@@ -1,0 +1,28 @@
+# Using fio
+
+Install `fio` with the host package manager. CSB provides native examples for
+buffered-read LRU activity and mq-deadline contention:
+
+```bash
+sudo scripts/run-single.sh config/bm-external/fio/lru-buffered-read.json
+sudo -E env CSB_FIO_DIRECTORY=/mnt/dedicated-test \
+  scripts/run-single.sh config/bm-external/fio/mq-deadline.json
+```
+
+The wrapper creates one uniquely named test file in `CSB_FIO_DIRECTORY` (or
+`/tmp`) and removes that exact file after each execution. Never point the
+mq-deadline case at a live-data filesystem. Verify the target block device's
+active scheduler in `/sys/block/DEVICE/queue/scheduler`; a successful smoke
+run on another scheduler is not validation of the mq-deadline patch.
+
+The committed file sizes, three-second duration, and single repetition are
+functional examples. For performance claims, provision a dedicated filesystem,
+increase the LRU working set beyond RAM, use at least 128 jobs and 120 seconds,
+add a 30-second ramp, and run at least five repetitions per kernel. Hold the
+device, scheduler, filesystem, mount options, affinity, and fio revision fixed.
+
+Compare bandwidth or IOPS together with p95, p99, and p99.9 completion latency,
+CPU cost per I/O, and device utilization. For the LRU case, confirm the target
+folio/LRU paths in a profile. For mq-deadline, confirm both the scheduler and
+the exact scheduler-lock path. The JSON adapter exposes these fio metrics
+directly to CSB plots and result CSV files.

--- a/doc/bm-runner.md
+++ b/doc/bm-runner.md
@@ -157,6 +157,7 @@ to add external benchmarks under the following conditions:
 
 CSB contains minimal examples for some external benchmarks like [fio][], [stress-ng][], [unixbench][], and [will-it-scale][].
 Each of these benchmarks have a JSON file under `config/` and an adapter under `scripts/adapters`.
+See [Using fio](bm-external/fio.md) for focused storage scalability examples.
 For [unixbench][] and [will-it-scale][] we recommend users to clone these repos under a folder called `bm-external` inside
 `CSB` directory.
 

--- a/scripts/adapters/fio-json-adapter.py
+++ b/scripts/adapters/fio-json-adapter.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import json
+import sys
+
+
+def add_metric(metrics, name, value):
+    if value is not None:
+        metrics.append(f"{name}={value}")
+
+
+def parse_fio(document):
+    jobs = document.get("jobs", [])
+    if not jobs:
+        raise ValueError("fio JSON contains no jobs")
+
+    job = jobs[0]
+    metrics = []
+    for name in ("error", "job_runtime", "usr_cpu", "sys_cpu"):
+        add_metric(metrics, name, job.get(name))
+
+    for direction in ("read", "write"):
+        values = job.get(direction, {})
+        for name in ("iops", "bw", "total_ios"):
+            add_metric(metrics, f"{direction}_{name}", values.get(name))
+        percentiles = values.get("clat_ns", {}).get("percentile", {})
+        for percentile, suffix in (
+            ("50.000000", "p50"),
+            ("95.000000", "p95"),
+            ("99.000000", "p99"),
+            ("99.900000", "p99_9"),
+        ):
+            add_metric(
+                metrics,
+                f"{direction}_clat_{suffix}_ns",
+                percentiles.get(percentile),
+            )
+
+    return metrics
+
+
+if __name__ == "__main__":
+    try:
+        print(";".join(parse_fio(json.load(sys.stdin))))
+    except (json.JSONDecodeError, ValueError) as error:
+        sys.exit(str(error))

--- a/scripts/bm-external/fio.sh
+++ b/scripts/bm-external/fio.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+fio_dir=${CSB_FIO_DIRECTORY:-/tmp}
+fio_file=$(mktemp --tmpdir="${fio_dir}" csb-fio.XXXXXX)
+cleanup()
+{
+    rm -f -- "${fio_file}"
+}
+trap cleanup EXIT
+
+fio "$@" --filename="${fio_file}"


### PR DESCRIPTION
## Add

- buffered-read LRU and mq-deadline fio scalability configs
- a JSON adapter for IOPS, bandwidth, CPU, and latency percentiles
- a temporary-file wrapper and focused adapter test

## Change

- document how to place the workload on a dedicated filesystem

## Fix

- remove each uniquely named workload file after its execution

## Note

- focused adapter test passes
- both configs passed through `scripts/run-single.sh` locally at
  1, 2, 4, and 8 jobs with fio error code zero
- the local mq-deadline run is a functional smoke test only; kernel-patch
  validation still requires a dedicated device using mq-deadline
