### PR TITLE
Add opt-in external benchmark setup

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -210,7 +210,7 @@ jobs:
           sudo apt-get install -y build-essential cmake libhiredis-dev libhwloc-dev ninja-build
       - name: Prepare benchmark
         run: |
-          ./scripts/bm-external/${{ matrix.benchmark.extern }}/configure.sh
+          ./scripts/bm-external/setup.sh ${{ matrix.benchmark.extern }}
       - name: Run Benchmark ${{ matrix.benchmark.config }}
         run: |
           ./scripts/run-single.sh config/${{ matrix.benchmark.dir }}/${{ matrix.benchmark.config }}.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ multidiff/
 Testing/
 gen-ws
 bm-external/byte-unixbench
+bm-external/fio
+bm-external/stress-ng
 bm-external/sysbench
 bm-external/will-it-scale
 bm-external/cgroups/rootfs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,3 +55,25 @@ add_custom_target(
     json-format-apply
     COMMAND bash -c ${HELPERS}/json-format.sh ${CMAKE_SOURCE_DIR}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+# ##############################################################################
+# Add external benchmark setup targets
+# ##############################################################################
+set(EXTERNAL_SETUP ${CMAKE_SOURCE_DIR}/scripts/bm-external/setup.sh)
+add_custom_target(
+    external-tools
+    COMMAND ${EXTERNAL_SETUP} --all
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    USES_TERMINAL VERBATIM)
+add_custom_target(
+    external-tools-check
+    COMMAND ${EXTERNAL_SETUP} --check
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    USES_TERMINAL VERBATIM)
+foreach(EXTERNAL_TOOL fio stress-ng byte-unixbench will-it-scale sysbench)
+    add_custom_target(
+        external-${EXTERNAL_TOOL}
+        COMMAND ${EXTERNAL_SETUP} ${EXTERNAL_TOOL}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        USES_TERMINAL VERBATIM)
+endforeach()

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ CSB
 ├── helpers             # helper scripts used for development and formatting
 └── scripts             # scripts that are used by the framework
     ├── adapters        # scripts used to transform external benchmarks output into a complying format
+    ├── bm-external     # download and build supported external benchmarks
     ├── fg-diff         # scripts used for selecting a set of distinct microbenchmarks
     └── plugins         # scripts used as an additional steps by some of the benchmarks
 ```

--- a/config/bm-external/fio.json
+++ b/config/bm-external/fio.json
@@ -52,6 +52,7 @@
   },
   "applications": [
     {
+      "path": "bm-external/fio",
       "name": "fio",
       "args": "--name=randrw --filename=/tmp/fio.test --rw=randrw --rwmixread=70 --bs=4k --size=1G --iodepth=64 --numjobs={threads} --direct=1",
       "adapter": {

--- a/config/bm-external/stress-ng.json
+++ b/config/bm-external/stress-ng.json
@@ -63,6 +63,7 @@
   },
   "applications": [
     {
+      "path": "bm-external/stress-ng",
       "name": "stress-ng",
       "args": "--futex {threads} -t {duration} -M",
       "adapter": {

--- a/doc/bm-external/sysbench.md
+++ b/doc/bm-external/sysbench.md
@@ -2,7 +2,7 @@
 
 Install sysbench dependencies. On openEuler:
 ```bash
-sudo dnf install mariadb-server mariadb-devel mariadb-connector-c postgresql-server postgresql-server-devel libpq libpq-devel autoconf automake libtool gcc make
+sudo dnf install mariadb-server mariadb-devel mariadb-connector-c postgresql-server postgresql-server-devel libpq libpq-devel autoconf automake libtool pkgconf-pkg-config gcc make
 ```
 
 Install sysbench from git tree using:

--- a/doc/bm-runner.md
+++ b/doc/bm-runner.md
@@ -155,10 +155,50 @@ to add external benchmarks under the following conditions:
 - Users should provide a relative path to the CSB project directory where the external benchmarks are located (see [applications config](bm-config.md#application)).
 - If the external benchmark is installed on the host (in /usr/bin), it can be run in the container, provided the container's OS matches the host's OS.
 
-CSB contains minimal examples for some external benchmarks like [fio][], [stress-ng][], [unixbench][], and [will-it-scale][].
-Each of these benchmarks have a JSON file under `config/` and an adapter under `scripts/adapters`.
-For [unixbench][] and [will-it-scale][] we recommend users to clone these repos under a folder called `bm-external` inside
-`CSB` directory.
+CSB contains examples for external benchmarks including [fio][], [stress-ng][],
+[unixbench][], [will-it-scale][], and [sysbench][]. Each benchmark has a JSON
+file under `config/bm-external/` and an adapter under `scripts/adapters/`.
+
+Download, build, and validate all supported source-built external benchmarks
+from the CSB project root with:
+
+```bash
+scripts/bm-external/setup.sh --all
+```
+
+External tool setup is opt-in. A normal CMake build, `scripts/prepare.sh`, and
+`run.sh` do not download or build any external benchmark.
+
+The source builds require Git, Make, and a C compiler. Will-it-scale also
+requires the hwloc development headers. Sysbench has additional database build
+dependencies documented in [Using Sysbench](bm-external/sysbench.md).
+
+The setup installs the tools below `bm-external/`, where the supplied JSON
+configs expect them. This directory is part of the CSB project mount used for
+container executions, so the same installation works for native and container
+runs.
+
+Individual tools, the `unixbench` alias, and installation checks are supported:
+
+```bash
+scripts/bm-external/setup.sh fio stress-ng will-it-scale
+scripts/bm-external/setup.sh unixbench sysbench
+scripts/bm-external/setup.sh --check
+scripts/bm-external/setup.sh --list
+```
+
+The same operations are available as CMake targets after configuring a build:
+
+```bash
+cmake --build build --target external-tools
+cmake --build build --target external-fio
+cmake --build build --target external-tools-check
+```
+
+The build scripts use pinned releases by default where upstream releases are
+available. `FIO_VERSION`, `STRESS_NG_VERSION`, `UNIXBENCH_VERSION`,
+`WILL_IT_SCALE_VERSION`, and `SYSBENCH_VERSION` can override their revisions.
+`BUILD_JOBS` controls build parallelism.
 
 ## Generating Configuration Files in Bulk
 
@@ -196,3 +236,4 @@ __Note: make sure to run in the project root, and remove existing build folder b
 [unixbench]: https://github.com/kdlucas/byte-unixbench
 [stress-ng]: https://github.com/ColinIanKing/stress-ng
 [will-it-scale]: https://github.com/antonblanchard/will-it-scale
+[sysbench]: https://github.com/akopytov/sysbench

--- a/doc/development.md
+++ b/doc/development.md
@@ -32,6 +32,12 @@ Prepare the Python and benchkit environment from the repository root:
 scripts/prepare.sh
 ```
 
+Install all supported source-built external benchmarks:
+
+```bash
+scripts/bm-external/setup.sh --all
+```
+
 Run the Python test suite from the repository root:
 
 ```bash
@@ -169,4 +175,3 @@ Add only the needed sections to describe the changes. Keep them concise.
 Extra elaborate information can be added in the form of comments to the PR.
 Restrict the PR title to 50chars if possible, and the commit message/description lines to 72 chars max.
 All commits should be signed with `-s`.
-

--- a/scripts/bm-external/common.sh
+++ b/scripts/bm-external/common.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+: "${CSB_ROOT:?CSB_ROOT must name the CSB source directory}"
+
+EXTERNAL_DIR="${CSB_EXTERNAL_DIR:-${CSB_ROOT}/bm-external}"
+BUILD_JOBS="${BUILD_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)}"
+
+info() {
+	printf '[external-setup] %s\n' "$*"
+}
+
+die() {
+	printf '[external-setup] error: %s\n' "$*" >&2
+	exit 1
+}
+
+require_command() {
+	command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+clone_release() {
+	repository=$1
+	directory=$2
+	revision=$3
+	require_command git
+
+	if [ -d "${directory}/.git" ]; then
+		if ! git -C "${directory}" diff --quiet ||
+			! git -C "${directory}" diff --cached --quiet; then
+			die "refusing to replace modified source tree ${directory}"
+		fi
+		info "updating ${directory} to ${revision}"
+		git -C "${directory}" fetch --depth 1 origin "${revision}"
+		git -C "${directory}" checkout --detach FETCH_HEAD
+		return
+	fi
+	if [ -e "${directory}" ]; then
+		die "${directory} exists but is not a git checkout"
+	fi
+
+	mkdir -p "$(dirname "${directory}")"
+	info "cloning ${repository} at ${revision}"
+	git clone --depth 1 --branch "${revision}" "${repository}" "${directory}"
+}

--- a/scripts/bm-external/fio/configure.sh
+++ b/scripts/bm-external/fio/configure.sh
@@ -9,15 +9,15 @@ CSB_ROOT="$(CDPATH='' cd -- "${SCRIPT_DIR}/../../.." && pwd)"
 export CSB_ROOT
 . "${CSB_ROOT}/scripts/bm-external/common.sh"
 
-UNIXBENCH_VERSION="${UNIXBENCH_VERSION:-v6.0.1}"
-SOURCE_DIR="${EXTERNAL_DIR}/byte-unixbench"
+FIO_VERSION="${FIO_VERSION:-fio-3.42}"
+SOURCE_DIR="${EXTERNAL_DIR}/fio"
 
 require_command make
-clone_release https://github.com/kdlucas/byte-unixbench.git "${SOURCE_DIR}" \
-	"${UNIXBENCH_VERSION}"
+clone_release https://github.com/axboe/fio.git "${SOURCE_DIR}" "${FIO_VERSION}"
 
 (
-	cd "${SOURCE_DIR}/UnixBench"
+	cd "${SOURCE_DIR}"
 	make clean >/dev/null 2>&1 || true
+	./configure
 	make -j "${BUILD_JOBS}"
 )

--- a/scripts/bm-external/setup.sh
+++ b/scripts/bm-external/setup.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+CSB_ROOT="$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)"
+export CSB_ROOT
+. "${SCRIPT_DIR}/common.sh"
+
+TOOLS="fio stress-ng byte-unixbench will-it-scale sysbench"
+
+usage() {
+	cat <<EOF
+Usage: $0 --all
+       $0 TOOL [TOOL ...]
+       $0 --check [TOOL ...]
+       $0 --list
+
+Download, build, and validate CSB's external benchmark tools under:
+  ${EXTERNAL_DIR}
+
+Supported tools:
+  ${TOOLS}
+
+The alias 'unixbench' is accepted for 'byte-unixbench'.
+Set CSB_EXTERNAL_DIR to use another installation directory.
+EOF
+}
+
+normalize_tool() {
+	case "$1" in
+	unixbench) printf '%s\n' byte-unixbench ;;
+	fio | stress-ng | byte-unixbench | will-it-scale | sysbench)
+		printf '%s\n' "$1"
+		;;
+	*) die "unsupported external tool: $1" ;;
+	esac
+}
+
+tool_executable() {
+	case "$1" in
+	fio) printf '%s\n' "${EXTERNAL_DIR}/fio/fio" ;;
+	stress-ng) printf '%s\n' "${EXTERNAL_DIR}/stress-ng/stress-ng" ;;
+	byte-unixbench)
+		printf '%s\n' "${EXTERNAL_DIR}/byte-unixbench/UnixBench/Run"
+		;;
+	will-it-scale)
+		printf '%s\n' "${EXTERNAL_DIR}/will-it-scale/malloc1_processes"
+		;;
+	sysbench) printf '%s\n' "${EXTERNAL_DIR}/sysbench/bin/sysbench" ;;
+	esac
+}
+
+check_tool() {
+	tool=$1
+	executable="$(tool_executable "${tool}")"
+	[ -x "${executable}" ] || die "${tool} is not installed: ${executable}"
+	info "${tool}: ready (${executable})"
+}
+
+setup_tool() {
+	tool=$1
+	"${SCRIPT_DIR}/${tool}/configure.sh"
+	check_tool "${tool}"
+}
+
+mode=setup
+case "${1:-}" in
+--all)
+	set -- fio stress-ng byte-unixbench will-it-scale sysbench
+	;;
+--check)
+	mode=check
+	shift
+	if [ "$#" -eq 0 ]; then
+		set -- fio stress-ng byte-unixbench will-it-scale sysbench
+	fi
+	;;
+--list)
+	printf '%s\n' fio stress-ng byte-unixbench will-it-scale sysbench
+	exit 0
+	;;
+-h | --help)
+	usage
+	exit 0
+	;;
+"")
+	usage >&2
+	exit 2
+	;;
+esac
+
+for requested_tool in "$@"; do
+	tool="$(normalize_tool "${requested_tool}")"
+	if [ "${mode}" = check ]; then
+		check_tool "${tool}"
+	else
+		setup_tool "${tool}"
+	fi
+done

--- a/scripts/bm-external/stress-ng/configure.sh
+++ b/scripts/bm-external/stress-ng/configure.sh
@@ -9,15 +9,15 @@ CSB_ROOT="$(CDPATH='' cd -- "${SCRIPT_DIR}/../../.." && pwd)"
 export CSB_ROOT
 . "${CSB_ROOT}/scripts/bm-external/common.sh"
 
-UNIXBENCH_VERSION="${UNIXBENCH_VERSION:-v6.0.1}"
-SOURCE_DIR="${EXTERNAL_DIR}/byte-unixbench"
+STRESS_NG_VERSION="${STRESS_NG_VERSION:-V0.22.00}"
+SOURCE_DIR="${EXTERNAL_DIR}/stress-ng"
 
 require_command make
-clone_release https://github.com/kdlucas/byte-unixbench.git "${SOURCE_DIR}" \
-	"${UNIXBENCH_VERSION}"
+clone_release https://github.com/ColinIanKing/stress-ng.git "${SOURCE_DIR}" \
+	"${STRESS_NG_VERSION}"
 
 (
-	cd "${SOURCE_DIR}/UnixBench"
+	cd "${SOURCE_DIR}"
 	make clean >/dev/null 2>&1 || true
 	make -j "${BUILD_JOBS}"
 )

--- a/scripts/bm-external/sysbench/configure.sh
+++ b/scripts/bm-external/sysbench/configure.sh
@@ -2,22 +2,29 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-set -ex
-SCRIPT_DIR="$(readlink -f $(dirname "$0")/../../../bm-external)"
+set -eu
 
-TAG=1.0.20
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+CSB_ROOT="$(CDPATH='' cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+export CSB_ROOT
+. "${CSB_ROOT}/scripts/bm-external/common.sh"
 
-mkdir -p ${SCRIPT_DIR}
+SYSBENCH_VERSION="${SYSBENCH_VERSION:-1.0.20}"
+SOURCE_DIR="${EXTERNAL_DIR}/sysbench"
+
+require_command make
+require_command autoconf
+require_command automake
+require_command libtoolize
+require_command pkg-config
+clone_release https://github.com/akopytov/sysbench.git "${SOURCE_DIR}" \
+	"${SYSBENCH_VERSION}"
+
 (
-	cd ${SCRIPT_DIR}
-	if [ ! -e sysbench/.git ]; then
-		git clone https://github.com/akopytov/sysbench --branch ${TAG}
-	else
-	    (cd sysbench && make clean|| true)
-	fi
-	cd sysbench
+	cd "${SOURCE_DIR}"
+	make clean >/dev/null 2>&1 || true
 	./autogen.sh
-	./configure --with-mysql --with-pgsql --prefix=${SCRIPT_DIR}/sysbench
-	make
+	./configure --with-mysql --with-pgsql --prefix="${SOURCE_DIR}"
+	make -j "${BUILD_JOBS}"
 	make install
 )

--- a/scripts/bm-external/will-it-scale/configure.sh
+++ b/scripts/bm-external/will-it-scale/configure.sh
@@ -2,20 +2,22 @@
 # Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-set -ex
-SRC_DIR="$(readlink -f $(dirname "$0")/../../..)"
-BUILD_DIR=${SRC_DIR}/bm-external
+set -eu
 
-echo $BUILD_DIR
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+CSB_ROOT="$(CDPATH='' cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+export CSB_ROOT
+. "${CSB_ROOT}/scripts/bm-external/common.sh"
 
-mkdir -p ${BUILD_DIR}
+WILL_IT_SCALE_VERSION="${WILL_IT_SCALE_VERSION:-master}"
+SOURCE_DIR="${EXTERNAL_DIR}/will-it-scale"
+
+require_command make
+clone_release https://github.com/antonblanchard/will-it-scale.git \
+	"${SOURCE_DIR}" "${WILL_IT_SCALE_VERSION}"
+
 (
-	cd ${BUILD_DIR}
-	if [ ! -e will-it-scale/.git ]; then
-		git clone https://github.com/antonblanchard/will-it-scale.git
-	else
-	    (cd will-it-scale && make clean|| true)
-	fi
-	cd will-it-scale
-	make
+	cd "${SOURCE_DIR}"
+	make clean >/dev/null 2>&1 || true
+	make -j "${BUILD_JOBS}"
 )


### PR DESCRIPTION
Add

- a unified setup and validation command for external benchmarks
- per-tool fio and stress-ng source builds
- explicit CMake setup and check targets

Change

- reuse common versioned source setup for existing external tools
- resolve fio and stress-ng from repository-local directories
- exercise the unified command in external benchmark CI

Note

- default builds and runtime preparation remain external-tool free