### PR TITLE
Add sysbench fileio example

### DIFF
--- a/bm-runner/tests/test_sysbench_fileio_adapter.py
+++ b/bm-runner/tests/test_sysbench_fileio_adapter.py
@@ -1,0 +1,31 @@
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import subprocess
+from pathlib import Path
+
+
+ADAPTER = Path(__file__).parents[2] / "scripts/adapters/sysbench-adapter.py"
+
+
+def test_sysbench_adapter_parses_fileio_metrics():
+    output = """\
+File operations:
+    reads/s:                      1234.56
+    writes/s:                     987.65
+
+Throughput:
+    read, MiB/s:                  4.82
+    written, MiB/s:               3.86
+
+Latency (ms):
+         min:                          0.01
+         avg:                          0.31
+         max:                          3.42
+         95th percentile:              0.95
+"""
+    result = subprocess.run([ADAPTER], input=output, text=True, capture_output=True, check=True)
+
+    assert "file_operations.reads_s=1234.56" in result.stdout
+    assert "throughput.read_mib_s=4.82" in result.stdout
+    assert "latency.95th_percentile=0.95" in result.stdout

--- a/config/bm-external/sysbench/fileio.json
+++ b/config/bm-external/sysbench/fileio.json
@@ -1,0 +1,66 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#sysbench threads",
+      "y": "file_operations.reads_s",
+      "y_lbl": "Reads/s",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "sysbench fileio read throughput"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "#sysbench threads",
+      "y": "latency.95th_percentile",
+      "y_lbl": "p95 latency (ms)",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "sysbench fileio p95 latency"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "scripts/bm-external",
+      "name": "sysbench-fileio.sh",
+      "args": "--threads={threads} --time={duration} --file-test-mode=rndrw --file-extra-flags=direct --file-fsync-freq=128",
+      "adapter": {
+        "name": "sysbench-adapter.py"
+      }
+    }
+  ]
+}

--- a/doc/bm-external/sysbench.md
+++ b/doc/bm-external/sysbench.md
@@ -14,3 +14,24 @@ To run just one instance in bare metal host, run:
 ```bash
 sudo scripts/bm-external/sysbench/prepare.py
 ```
+
+## File I/O scalability
+
+The host-package `sysbench` can also run a self-contained native fileio sweep:
+
+```bash
+sudo -E scripts/run-single.sh config/bm-external/sysbench/fileio.json
+```
+
+The wrapper prepares a uniquely named temporary file set for every execution
+and removes that exact directory afterward. Set `CSB_SYSBENCH_FILE_NUM` and
+`CSB_SYSBENCH_FILE_SIZE` to change the default 32 files and 256 MiB total.
+
+The committed three-second, single-repeat case is a functional example. For an
+mq-deadline comparison, use a dedicated filesystem on a device whose active
+scheduler is verified, prepare at least 32 GiB, use the target high thread
+count and a 30-second warm-up followed by at least 120 timed seconds. Run at
+least five repetitions on each kernel with identical device, scheduler,
+filesystem, affinity, and sysbench version. Compare reads/s, writes/s, and p95
+latency. fio remains the primary scheduler test because it exposes more I/O
+controls and latency percentiles.

--- a/doc/bm-runner.md
+++ b/doc/bm-runner.md
@@ -155,7 +155,7 @@ to add external benchmarks under the following conditions:
 - Users should provide a relative path to the CSB project directory where the external benchmarks are located (see [applications config](bm-config.md#application)).
 - If the external benchmark is installed on the host (in /usr/bin), it can be run in the container, provided the container's OS matches the host's OS.
 
-CSB contains minimal examples for some external benchmarks like [fio][], [stress-ng][], [unixbench][], and [will-it-scale][].
+CSB contains minimal examples for some external benchmarks like [fio][], [stress-ng][], [sysbench][], [unixbench][], and [will-it-scale][].
 Each of these benchmarks have a JSON file under `config/` and an adapter under `scripts/adapters`.
 For [unixbench][] and [will-it-scale][] we recommend users to clone these repos under a folder called `bm-external` inside
 `CSB` directory.
@@ -195,4 +195,5 @@ __Note: make sure to run in the project root, and remove existing build folder b
 [fio]: https://github.com/axboe/fio
 [unixbench]: https://github.com/kdlucas/byte-unixbench
 [stress-ng]: https://github.com/ColinIanKing/stress-ng
+[sysbench]: https://github.com/akopytov/sysbench
 [will-it-scale]: https://github.com/antonblanchard/will-it-scale

--- a/scripts/bm-external/sysbench-fileio.sh
+++ b/scripts/bm-external/sysbench-fileio.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+work_dir=$(mktemp -d /tmp/csb-sysbench-fileio.XXXXXX)
+file_num=${CSB_SYSBENCH_FILE_NUM:-32}
+file_size=${CSB_SYSBENCH_FILE_SIZE:-256M}
+
+cleanup()
+{
+    status=$?
+    cd /
+    rm -rf -- "${work_dir}"
+    exit "${status}"
+}
+trap cleanup EXIT
+
+cd "${work_dir}"
+sysbench fileio --file-num="${file_num}" --file-total-size="${file_size}" \
+    prepare >/dev/null
+sysbench fileio --file-num="${file_num}" --file-total-size="${file_size}" \
+    "$@" run


### PR DESCRIPTION
## Add

- a self-contained sysbench fileio scalability config
- temporary dataset preparation and cleanup wrapper
- focused adapter coverage for fileio output

## Change

- document production-sized mq-deadline confirmation settings
- list sysbench among the supported external examples

## Fix

- none

## Note

- focused adapter test passes
- the config passed through `scripts/run-single.sh` locally at
  1, 2, 4, and 8 threads and produced throughput and p95 latency
- the committed dataset and duration are intentionally smoke-test sized
