### PR TITLE
Add will-it-scale uname example

### DIFF
--- a/config/bm-external/will-it-scale/uname.json
+++ b/config/bm-external/will-it-scale/uname.json
@@ -1,0 +1,56 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "#will-it-scale threads",
+      "y": "average",
+      "y_lbl": "uname operations/s",
+      "hue": "execution_type",
+      "hue_lbl": "Execution environment",
+      "shape": "lineplot",
+      "title": "will-it-scale uname throughput"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 3,
+    "repeat": 1,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          2,
+          4,
+          8
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 8,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    }
+  },
+  "applications": [
+    {
+      "path": "bm-external/will-it-scale",
+      "name": "uname1_threads",
+      "args": "-n -t {threads} -s {duration}",
+      "adapter": {
+        "name": "will-it-scale-adapter.sh"
+      }
+    }
+  ]
+}

--- a/doc/bm-external/will-it-scale.md
+++ b/doc/bm-external/will-it-scale.md
@@ -1,0 +1,26 @@
+# Using will-it-scale
+
+Install a C compiler, make, and the hwloc development package, then clone and
+build the pinned external harness with CSB's configure script:
+
+```bash
+scripts/bm-external/will-it-scale/configure.sh
+sudo scripts/run-single.sh config/bm-external/will-it-scale/uname.json
+```
+
+The configure script copies CSB's published `uname1.c` test into the external
+checkout before building its process and thread executables. The CSB config
+runs the thread variant because readers in one UTS namespace contend on the
+same kernel state. Run the process variant separately as a useful control.
+
+The committed settings are a functional 1/2/4/8-thread example. For kernel
+performance claims, include every relevant task count through the machine's
+CPU count, run at least five complete sweeps per kernel, and keep the harness
+revision, topology, affinity, and frequency policy fixed. Compare operations/s
+and scaling relative to one thread. Profile the old and candidate kernels to
+confirm reduced reader-side UTS lock/cacheline traffic, and run a concurrent
+hostname writer test separately to validate coherent snapshots and retry
+behavior.
+
+Neither sysbench nor UnixBench contains a timed, high-concurrency `uname()`
+workload, so their aggregate scores are not evidence for the UTS patch.

--- a/doc/bm-runner.md
+++ b/doc/bm-runner.md
@@ -157,6 +157,8 @@ to add external benchmarks under the following conditions:
 
 CSB contains minimal examples for some external benchmarks like [fio][], [stress-ng][], [unixbench][], and [will-it-scale][].
 Each of these benchmarks have a JSON file under `config/` and an adapter under `scripts/adapters`.
+See [Using will-it-scale](bm-external/will-it-scale.md) for the UTS read
+scalability testcase.
 For [unixbench][] and [will-it-scale][] we recommend users to clone these repos under a folder called `bm-external` inside
 `CSB` directory.
 

--- a/scripts/bm-external/will-it-scale/configure.sh
+++ b/scripts/bm-external/will-it-scale/configure.sh
@@ -17,5 +17,6 @@ mkdir -p ${BUILD_DIR}
 	    (cd will-it-scale && make clean|| true)
 	fi
 	cd will-it-scale
+	cp "${SRC_DIR}/scripts/bm-external/will-it-scale/uname1.c" tests/uname1.c
 	make
 )

--- a/scripts/bm-external/will-it-scale/uname1.c
+++ b/scripts/bm-external/will-it-scale/uname1.c
@@ -1,0 +1,18 @@
+// Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <sys/utsname.h>
+
+char *testcase_description = "uname system call";
+
+void
+testcase(unsigned long long *iterations, unsigned long nr)
+{
+    struct utsname name;
+
+    (void)nr;
+    while (1) {
+        uname(&name);
+        (*iterations)++;
+    }
+}


### PR DESCRIPTION
## Add

- a published will-it-scale `uname()` testcase
- a native thread-scaling CSB config
- UTS patch validation guidance

## Change

- install the CSB testcase into the external checkout before building

## Fix

- none

## Note

- both process and thread executables build successfully
- the thread config passed through `scripts/run-single.sh` locally at
  1, 2, 4, and 8 threads and produced an average operations/s metric
- a concurrent UTS writer remains a separate correctness requirement
