### PR TITLE
bench: add warm CI fanout workloads

### DIFF
--- a/bm-external/active-mm-scalability/.gitignore
+++ b/bm-external/active-mm-scalability/.gitignore
@@ -1,0 +1,1 @@
+/active-mm-scalability

--- a/bm-external/active-mm-scalability/active-mm-scalability.c
+++ b/bm-external/active-mm-scalability/active-mm-scalability.c
@@ -5,6 +5,7 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <linux/mount.h>
 #include <sched.h>
 #include <stdint.h>
@@ -12,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/syscall.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
@@ -24,6 +26,8 @@ struct result {
 struct worker_state {
     unsigned int index;
     uint32_t sequence;
+    char base[PATH_MAX];
+    char new_root[PATH_MAX];
 };
 
 static double
@@ -153,6 +157,38 @@ op_proc_filesystems(struct worker_state *state)
     return n < 0 ? -1 : 0;
 }
 
+static int
+op_pivot_root(struct worker_state *state)
+{
+    pid_t pid = fork();
+    int status;
+
+    if (pid < 0)
+        return -1;
+    if (!pid) {
+        char old_root[PATH_MAX];
+        struct stat root_stat, old_stat;
+
+        if (unshare(CLONE_NEWNS) ||
+            syscall(SYS_mount, NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL) ||
+            syscall(SYS_mount, "tmpfs", state->new_root, "tmpfs", 0,
+                    "size=4m") ||
+            (size_t)snprintf(old_root, sizeof(old_root), "%s/old-root",
+                             state->new_root) >= sizeof(old_root) ||
+            mkdir(old_root, 0700) || chdir(state->new_root) ||
+            syscall(SYS_pivot_root, ".", "old-root") || chdir("/") ||
+            stat("/", &root_stat) || stat("/old-root", &old_stat) ||
+            (root_stat.st_dev == old_stat.st_dev &&
+             root_stat.st_ino == old_stat.st_ino))
+            _exit(1);
+        _exit(0);
+    }
+    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status) ||
+        WEXITSTATUS(status))
+        return -1;
+    return 0;
+}
+
 static int (*select_operation(const char *test))(struct worker_state *)
 {
     if (!strcmp(test, "uid-unique"))
@@ -165,6 +201,8 @@ static int (*select_operation(const char *test))(struct worker_state *)
         return op_fsopen;
     if (!strcmp(test, "proc-filesystems"))
         return op_proc_filesystems;
+    if (!strcmp(test, "pivot-root"))
+        return op_pivot_root;
     return NULL;
 }
 
@@ -179,6 +217,16 @@ worker(unsigned int index, double deadline, int result_fd,
         result.failures++;
         goto out;
     }
+    if (operation == op_pivot_root &&
+        ((size_t)snprintf(state.base, sizeof(state.base),
+                          "/tmp/active-mm-pivot-%ld",
+                          (long)getpid()) >= sizeof(state.base) ||
+         (size_t)snprintf(state.new_root, sizeof(state.new_root), "%s/new-root",
+                          state.base) >= sizeof(state.new_root) ||
+         mkdir(state.base, 0700) || mkdir(state.new_root, 0700))) {
+        result.failures++;
+        goto out;
+    }
     while (now() < deadline) {
         if (operation(&state)) {
             result.failures++;
@@ -186,6 +234,9 @@ worker(unsigned int index, double deadline, int result_fd,
         }
         result.operations++;
     }
+    if (operation == op_pivot_root &&
+        (rmdir(state.new_root) || rmdir(state.base)))
+        result.failures++;
 out:
     if (write(result_fd, &result, sizeof(result)) != sizeof(result))
         perror("result write");
@@ -206,14 +257,14 @@ main(int argc, char **argv)
     if (argc != 4 || !(operation = select_operation(argv[1]))) {
         fprintf(stderr,
                 "usage: %s uid-unique|uid-shared|netns|fsopen|"
-                "proc-filesystems WORKERS DURATION_SECONDS\n",
+                "proc-filesystems|pivot-root WORKERS DURATION_SECONDS\n",
                 argv[0]);
         return 2;
     }
     workers  = parse_uint(argv[2], "workers");
     duration = parse_uint(argv[3], "duration");
     if ((!strncmp(argv[1], "uid-", 4) || !strcmp(argv[1], "netns") ||
-         !strcmp(argv[1], "fsopen")) &&
+         !strcmp(argv[1], "fsopen") || !strcmp(argv[1], "pivot-root")) &&
         geteuid()) {
         fprintf(stderr, "%s must run as root\n", argv[1]);
         return 2;

--- a/bm-external/active-mm-scalability/active-mm-scalability.c
+++ b/bm-external/active-mm-scalability/active-mm-scalability.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/mount.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+struct result {
+    uint64_t operations;
+    uint64_t failures;
+};
+
+struct worker_state {
+    unsigned int index;
+    uint32_t sequence;
+};
+
+static double
+now(void)
+{
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+        perror("clock_gettime");
+        exit(2);
+    }
+    return ts.tv_sec + ts.tv_nsec / 1000000000.0;
+}
+
+static unsigned int
+parse_uint(const char *text, const char *name)
+{
+    char *end;
+    unsigned long value = strtoul(text, &end, 10);
+
+    if (!*text || *end || !value || value > 4096) {
+        fprintf(stderr, "%s must be a positive integer: %s\n", name, text);
+        exit(2);
+    }
+    return value;
+}
+
+static int
+pin_worker(unsigned int worker)
+{
+    cpu_set_t allowed, one;
+    unsigned int seen = 0;
+    int cpu;
+
+    if (sched_getaffinity(0, sizeof(allowed), &allowed))
+        return -1;
+    for (cpu = 0; cpu < CPU_SETSIZE; cpu++) {
+        if (!CPU_ISSET(cpu, &allowed))
+            continue;
+        if (seen++ != worker)
+            continue;
+        CPU_ZERO(&one);
+        CPU_SET(cpu, &one);
+        return sched_setaffinity(0, sizeof(one), &one);
+    }
+    errno = E2BIG;
+    return -1;
+}
+
+static int
+op_uid_unique(struct worker_state *state)
+{
+    uid_t uid =
+        1000000U + state->index * 131071U + (state->sequence++ & 65535U);
+
+    if (setresuid(uid, (uid_t)-1, 0) || getuid() != uid ||
+        setresuid(0, (uid_t)-1, 0) || getuid() != 0)
+        return -1;
+    return 0;
+}
+
+static int
+op_uid_shared(struct worker_state *state)
+{
+    uid_t uid = 1000000U + (state->sequence++ & 65535U);
+
+    if (setresuid(uid, (uid_t)-1, 0) || getuid() != uid ||
+        setresuid(0, (uid_t)-1, 0) || getuid() != 0)
+        return -1;
+    return 0;
+}
+
+static int
+op_netns(struct worker_state *state)
+{
+    pid_t pid = fork();
+    int status;
+
+    (void)state;
+    if (pid < 0)
+        return -1;
+    if (!pid) {
+        int fd;
+
+        if (unshare(CLONE_NEWNET))
+            _exit(1);
+        fd = open("/sys/class/net/lo", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        if (fd < 0)
+            _exit(1);
+        close(fd);
+        _exit(0);
+    }
+    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status) ||
+        WEXITSTATUS(status))
+        return -1;
+    return 0;
+}
+
+static int
+op_fsopen(struct worker_state *state)
+{
+    int fd;
+
+    (void)state;
+    fd = syscall(__NR_fsopen, "tmpfs", FSOPEN_CLOEXEC);
+    if (fd < 0)
+        return -1;
+    return close(fd);
+}
+
+static int
+op_proc_filesystems(struct worker_state *state)
+{
+    char buf[4096];
+    ssize_t n;
+    int fd;
+
+    (void)state;
+    fd = open("/proc/filesystems", O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+        return -1;
+    do {
+        n = read(fd, buf, sizeof(buf));
+    } while (n > 0);
+    if (close(fd))
+        return -1;
+    return n < 0 ? -1 : 0;
+}
+
+static int (*select_operation(const char *test))(struct worker_state *)
+{
+    if (!strcmp(test, "uid-unique"))
+        return op_uid_unique;
+    if (!strcmp(test, "uid-shared"))
+        return op_uid_shared;
+    if (!strcmp(test, "netns"))
+        return op_netns;
+    if (!strcmp(test, "fsopen"))
+        return op_fsopen;
+    if (!strcmp(test, "proc-filesystems"))
+        return op_proc_filesystems;
+    return NULL;
+}
+
+static void
+worker(unsigned int index, double deadline, int result_fd,
+       int (*operation)(struct worker_state *))
+{
+    struct worker_state state = {.index = index};
+    struct result result      = {0};
+
+    if (pin_worker(index)) {
+        result.failures++;
+        goto out;
+    }
+    while (now() < deadline) {
+        if (operation(&state)) {
+            result.failures++;
+            break;
+        }
+        result.operations++;
+    }
+out:
+    if (write(result_fd, &result, sizeof(result)) != sizeof(result))
+        perror("result write");
+    close(result_fd);
+    _exit(result.failures ? 1 : 0);
+}
+
+int
+main(int argc, char **argv)
+{
+    int (*operation)(struct worker_state *);
+    struct result total = {0};
+    unsigned int workers, duration, i;
+    int(*pipes)[2];
+    pid_t *pids;
+    double start, deadline, elapsed;
+
+    if (argc != 4 || !(operation = select_operation(argv[1]))) {
+        fprintf(stderr,
+                "usage: %s uid-unique|uid-shared|netns|fsopen|"
+                "proc-filesystems WORKERS DURATION_SECONDS\n",
+                argv[0]);
+        return 2;
+    }
+    workers  = parse_uint(argv[2], "workers");
+    duration = parse_uint(argv[3], "duration");
+    if ((!strncmp(argv[1], "uid-", 4) || !strcmp(argv[1], "netns") ||
+         !strcmp(argv[1], "fsopen")) &&
+        geteuid()) {
+        fprintf(stderr, "%s must run as root\n", argv[1]);
+        return 2;
+    }
+    if (!strcmp(argv[1], "fsopen") && operation(&(struct worker_state){0})) {
+        fprintf(stderr, "fsopen preflight failed: %s\n", strerror(errno));
+        return 2;
+    }
+    pipes = calloc(workers, sizeof(*pipes));
+    pids  = calloc(workers, sizeof(*pids));
+    if (!pipes || !pids) {
+        perror("calloc");
+        return 2;
+    }
+    for (i = 0; i < workers; i++)
+        if (pipe2(pipes[i], O_CLOEXEC)) {
+            perror("pipe2");
+            return 2;
+        }
+    start    = now();
+    deadline = start + duration;
+    for (i = 0; i < workers; i++) {
+        pids[i] = fork();
+        if (pids[i] < 0) {
+            perror("fork");
+            return 2;
+        }
+        if (!pids[i]) {
+            unsigned int j;
+
+            for (j = 0; j < workers; j++) {
+                close(pipes[j][0]);
+                if (j != i)
+                    close(pipes[j][1]);
+            }
+            worker(i, deadline, pipes[i][1], operation);
+        }
+        close(pipes[i][1]);
+    }
+    for (i = 0; i < workers; i++) {
+        struct result one = {0};
+        int status;
+
+        if (read(pipes[i][0], &one, sizeof(one)) != sizeof(one))
+            total.failures++;
+        close(pipes[i][0]);
+        if (waitpid(pids[i], &status, 0) != pids[i] || !WIFEXITED(status) ||
+            WEXITSTATUS(status))
+            total.failures++;
+        total.operations += one.operations;
+        total.failures += one.failures;
+    }
+    elapsed = now() - start;
+    /* Network namespace destruction completes on a workqueue. */
+    if (!strcmp(argv[1], "netns"))
+        sleep(1);
+    printf(
+        "operations_per_second=%.3f;operations=%llu;failures=%llu;"
+        "elapsed_seconds=%.6f;workers=%u;test=%s;\n",
+        total.operations / elapsed, (unsigned long long)total.operations,
+        (unsigned long long)total.failures, elapsed, workers, argv[1]);
+    free(pids);
+    free(pipes);
+    return total.failures ? 1 : 0;
+}

--- a/bm-external/ci-fanout/.gitignore
+++ b/bm-external/ci-fanout/.gitignore
@@ -1,0 +1,1 @@
+/ci-fanout-micro

--- a/bm-external/ci-fanout/Makefile
+++ b/bm-external/ci-fanout/Makefile
@@ -1,0 +1,13 @@
+SHELL := /bin/sh
+
+CC ?= cc
+STEPS ?= 1024
+FIXTURE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))ci-step.c
+TARGETS := $(addprefix ci-step-,$(shell seq 1 $(STEPS)))
+
+.PHONY: all $(TARGETS)
+
+all: $(TARGETS)
+
+$(TARGETS):
+	@set -e; $(CC) -fsyntax-only -std=c11 -Wall -Wextra $(FIXTURE); test -r /proc/self/status

--- a/bm-external/ci-fanout/ci-fanout-micro.c
+++ b/bm-external/ci-fanout/ci-fanout-micro.c
@@ -1,0 +1,205 @@
+// Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+extern char **environ;
+
+struct worker {
+    pthread_barrier_t *barrier;
+    uint64_t *deadline_ns;
+    uint64_t completed;
+    uint64_t failures;
+    uint64_t total_ns;
+    uint64_t max_ns;
+};
+
+static uint64_t now_ns(void)
+{
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        perror("clock_gettime");
+        exit(EXIT_FAILURE);
+    }
+    return (uint64_t)ts.tv_sec * UINT64_C(1000000000) + (uint64_t)ts.tv_nsec;
+}
+
+static void *run_worker(void *argument)
+{
+    static char *const child_argv[] = {"true", NULL};
+    struct worker *worker = argument;
+
+    pthread_barrier_wait(worker->barrier);
+    while (now_ns() < *worker->deadline_ns) {
+        uint64_t start_ns = now_ns();
+        pid_t pid = fork();
+        int status = 0;
+        pid_t waited;
+        int failed = 0;
+
+        if (pid == 0) {
+            execve("/bin/true", child_argv, environ);
+            _exit(127);
+        }
+        if (pid < 0) {
+            failed = 1;
+        } else {
+            do {
+                waited = waitpid(pid, &status, 0);
+            } while (waited < 0 && errno == EINTR);
+            if (waited != pid || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+                failed = 1;
+        }
+
+        uint64_t elapsed_ns = now_ns() - start_ns;
+        worker->total_ns += elapsed_ns;
+        if (elapsed_ns > worker->max_ns)
+            worker->max_ns = elapsed_ns;
+        if (failed)
+            worker->failures++;
+        else
+            worker->completed++;
+    }
+    return NULL;
+}
+
+static uint64_t parse_uint(const char *name, const char *text, uint64_t min, uint64_t max)
+{
+    char *end = NULL;
+    unsigned long long value;
+
+    errno = 0;
+    value = strtoull(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' || value < min || value > max) {
+        fprintf(stderr, "%s must be an integer in [%" PRIu64 ", %" PRIu64 "]\n",
+                name, min, max);
+        exit(2);
+    }
+    return (uint64_t)value;
+}
+
+static double parse_duration(const char *text)
+{
+    char *end = NULL;
+    double value;
+
+    errno = 0;
+    value = strtod(text, &end);
+    if (errno != 0 || end == text || *end != '\0' || value < 0.1 || value > 3600.0) {
+        fputs("--duration must be in [0.1, 3600] seconds\n", stderr);
+        exit(2);
+    }
+    return value;
+}
+
+int main(int argc, char **argv)
+{
+    uint64_t worker_count = 1;
+    uint64_t memory_mib = 256;
+    double duration = 10.0;
+    pthread_barrier_t barrier;
+    pthread_t *threads;
+    struct worker *workers;
+    volatile unsigned char *memory = NULL;
+    uint64_t deadline_ns;
+    uint64_t start_ns;
+    uint64_t end_ns;
+    uint64_t completed = 0;
+    uint64_t failures = 0;
+    uint64_t total_ns = 0;
+    uint64_t max_ns = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (i + 1 >= argc) {
+            fprintf(stderr, "Usage: %s --workers N --duration SEC --memory-mib N\n", argv[0]);
+            return 2;
+        }
+        if (strcmp(argv[i], "--workers") == 0)
+            worker_count = parse_uint("--workers", argv[++i], 1, 1024);
+        else if (strcmp(argv[i], "--duration") == 0)
+            duration = parse_duration(argv[++i]);
+        else if (strcmp(argv[i], "--memory-mib") == 0)
+            memory_mib = parse_uint("--memory-mib", argv[++i], 0, 16384);
+        else {
+            fprintf(stderr, "Unknown option: %s\n", argv[i]);
+            return 2;
+        }
+    }
+
+    if (memory_mib > 0) {
+        size_t bytes = (size_t)memory_mib * 1024 * 1024;
+
+        memory = mmap(NULL, bytes, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (memory == MAP_FAILED) {
+            perror("mmap");
+            return 1;
+        }
+        for (size_t offset = 0; offset < bytes; offset += (size_t)getpagesize())
+            memory[offset] = (unsigned char)(offset >> 12);
+    }
+
+    threads = calloc((size_t)worker_count, sizeof(*threads));
+    workers = calloc((size_t)worker_count, sizeof(*workers));
+    if (threads == NULL || workers == NULL) {
+        perror("calloc");
+        return 1;
+    }
+    if (pthread_barrier_init(&barrier, NULL, (unsigned int)worker_count + 1) != 0) {
+        fputs("pthread_barrier_init failed\n", stderr);
+        return 1;
+    }
+    for (uint64_t i = 0; i < worker_count; i++) {
+        workers[i].barrier = &barrier;
+        workers[i].deadline_ns = &deadline_ns;
+        if (pthread_create(&threads[i], NULL, run_worker, &workers[i]) != 0) {
+            fputs("pthread_create failed\n", stderr);
+            return 1;
+        }
+    }
+
+    start_ns = now_ns();
+    deadline_ns = start_ns + (uint64_t)(duration * 1000000000.0);
+    pthread_barrier_wait(&barrier);
+    for (uint64_t i = 0; i < worker_count; i++) {
+        pthread_join(threads[i], NULL);
+        completed += workers[i].completed;
+        failures += workers[i].failures;
+        total_ns += workers[i].total_ns;
+        if (workers[i].max_ns > max_ns)
+            max_ns = workers[i].max_ns;
+    }
+    end_ns = now_ns();
+
+    double elapsed = (double)(end_ns - start_ns) / 1000000000.0;
+    uint64_t attempts = completed + failures;
+    double throughput = elapsed > 0.0 ? (double)completed / elapsed : 0.0;
+    double mean_us = attempts > 0 ? (double)total_ns / (double)attempts / 1000.0 : 0.0;
+
+    printf("fork_execs_per_second=%.6f;completed=%" PRIu64 ";failures=%" PRIu64
+           ";elapsed_seconds=%.6f;mean_fork_exec_us=%.3f;max_fork_exec_us=%.3f"
+           ";workers=%" PRIu64 ";runner_memory_mib=%" PRIu64 ";\n",
+           throughput, completed, failures, elapsed, mean_us,
+           (double)max_ns / 1000.0, worker_count, memory_mib);
+
+    if (memory != NULL)
+        munmap((void *)memory, (size_t)memory_mib * 1024 * 1024);
+    pthread_barrier_destroy(&barrier);
+    free(workers);
+    free(threads);
+    return failures == 0 ? 0 : 1;
+}

--- a/bm-external/ci-fanout/ci-fanout-micro.c
+++ b/bm-external/ci-fanout/ci-fanout-micro.c
@@ -27,7 +27,8 @@ struct worker {
     uint64_t max_ns;
 };
 
-static uint64_t now_ns(void)
+static uint64_t
+now_ns(void)
 {
     struct timespec ts;
 
@@ -38,16 +39,17 @@ static uint64_t now_ns(void)
     return (uint64_t)ts.tv_sec * UINT64_C(1000000000) + (uint64_t)ts.tv_nsec;
 }
 
-static void *run_worker(void *argument)
+static void *
+run_worker(void *argument)
 {
     static char *const child_argv[] = {"true", NULL};
-    struct worker *worker = argument;
+    struct worker *worker           = argument;
 
     pthread_barrier_wait(worker->barrier);
     while (now_ns() < *worker->deadline_ns) {
         uint64_t start_ns = now_ns();
-        pid_t pid = fork();
-        int status = 0;
+        pid_t pid         = fork();
+        int status        = 0;
         pid_t waited;
         int failed = 0;
 
@@ -77,14 +79,16 @@ static void *run_worker(void *argument)
     return NULL;
 }
 
-static uint64_t parse_uint(const char *name, const char *text, uint64_t min, uint64_t max)
+static uint64_t
+parse_uint(const char *name, const char *text, uint64_t min, uint64_t max)
 {
     char *end = NULL;
     unsigned long long value;
 
     errno = 0;
     value = strtoull(text, &end, 10);
-    if (errno != 0 || end == text || *end != '\0' || value < min || value > max) {
+    if (errno != 0 || end == text || *end != '\0' || value < min ||
+        value > max) {
         fprintf(stderr, "%s must be an integer in [%" PRIu64 ", %" PRIu64 "]\n",
                 name, min, max);
         exit(2);
@@ -92,25 +96,28 @@ static uint64_t parse_uint(const char *name, const char *text, uint64_t min, uin
     return (uint64_t)value;
 }
 
-static double parse_duration(const char *text)
+static double
+parse_duration(const char *text)
 {
     char *end = NULL;
     double value;
 
     errno = 0;
     value = strtod(text, &end);
-    if (errno != 0 || end == text || *end != '\0' || value < 0.1 || value > 3600.0) {
+    if (errno != 0 || end == text || *end != '\0' || value < 0.1 ||
+        value > 3600.0) {
         fputs("--duration must be in [0.1, 3600] seconds\n", stderr);
         exit(2);
     }
     return value;
 }
 
-int main(int argc, char **argv)
+int
+main(int argc, char **argv)
 {
     uint64_t worker_count = 1;
-    uint64_t memory_mib = 256;
-    double duration = 10.0;
+    uint64_t memory_mib   = 256;
+    double duration       = 10.0;
     pthread_barrier_t barrier;
     pthread_t *threads;
     struct worker *workers;
@@ -119,13 +126,15 @@ int main(int argc, char **argv)
     uint64_t start_ns;
     uint64_t end_ns;
     uint64_t completed = 0;
-    uint64_t failures = 0;
-    uint64_t total_ns = 0;
-    uint64_t max_ns = 0;
+    uint64_t failures  = 0;
+    uint64_t total_ns  = 0;
+    uint64_t max_ns    = 0;
 
     for (int i = 1; i < argc; i++) {
         if (i + 1 >= argc) {
-            fprintf(stderr, "Usage: %s --workers N --duration SEC --memory-mib N\n", argv[0]);
+            fprintf(stderr,
+                    "Usage: %s --workers N --duration SEC --memory-mib N\n",
+                    argv[0]);
             return 2;
         }
         if (strcmp(argv[i], "--workers") == 0)
@@ -159,12 +168,13 @@ int main(int argc, char **argv)
         perror("calloc");
         return 1;
     }
-    if (pthread_barrier_init(&barrier, NULL, (unsigned int)worker_count + 1) != 0) {
+    if (pthread_barrier_init(&barrier, NULL, (unsigned int)worker_count + 1) !=
+        0) {
         fputs("pthread_barrier_init failed\n", stderr);
         return 1;
     }
     for (uint64_t i = 0; i < worker_count; i++) {
-        workers[i].barrier = &barrier;
+        workers[i].barrier     = &barrier;
         workers[i].deadline_ns = &deadline_ns;
         if (pthread_create(&threads[i], NULL, run_worker, &workers[i]) != 0) {
             fputs("pthread_create failed\n", stderr);
@@ -172,7 +182,7 @@ int main(int argc, char **argv)
         }
     }
 
-    start_ns = now_ns();
+    start_ns    = now_ns();
     deadline_ns = start_ns + (uint64_t)(duration * 1000000000.0);
     pthread_barrier_wait(&barrier);
     for (uint64_t i = 0; i < worker_count; i++) {
@@ -185,10 +195,11 @@ int main(int argc, char **argv)
     }
     end_ns = now_ns();
 
-    double elapsed = (double)(end_ns - start_ns) / 1000000000.0;
+    double elapsed    = (double)(end_ns - start_ns) / 1000000000.0;
     uint64_t attempts = completed + failures;
     double throughput = elapsed > 0.0 ? (double)completed / elapsed : 0.0;
-    double mean_us = attempts > 0 ? (double)total_ns / (double)attempts / 1000.0 : 0.0;
+    double mean_us =
+        attempts > 0 ? (double)total_ns / (double)attempts / 1000.0 : 0.0;
 
     printf("fork_execs_per_second=%.6f;completed=%" PRIu64 ";failures=%" PRIu64
            ";elapsed_seconds=%.6f;mean_fork_exec_us=%.3f;max_fork_exec_us=%.3f"

--- a/bm-external/ci-fanout/ci-fanout.sh
+++ b/bm-external/ci-fanout/ci-fanout.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+workers=1
+steps=1024
+warmup_steps=32
+
+usage()
+{
+    echo "Usage: $0 [--workers N] [--steps N] [--warmup-steps N]" >&2
+}
+
+require_uint()
+{
+    name=$1
+    value=$2
+    case "$value" in
+        ''|*[!0-9]*)
+            echo "$name must be a positive integer" >&2
+            exit 2
+            ;;
+    esac
+    if [ "$value" -lt 1 ]; then
+        echo "$name must be a positive integer" >&2
+        exit 2
+    fi
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --workers)
+            [ "$#" -ge 2 ] || { usage; exit 2; }
+            workers=$2
+            shift 2
+            ;;
+        --steps)
+            [ "$#" -ge 2 ] || { usage; exit 2; }
+            steps=$2
+            shift 2
+            ;;
+        --warmup-steps)
+            [ "$#" -ge 2 ] || { usage; exit 2; }
+            warmup_steps=$2
+            shift 2
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+require_uint --workers "$workers"
+require_uint --steps "$steps"
+require_uint --warmup-steps "$warmup_steps"
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+makefile=$script_dir/Makefile
+
+for command in make cc date awk; do
+    command -v "$command" >/dev/null 2>&1 || {
+        echo "Required command is unavailable: $command" >&2
+        exit 1
+    }
+done
+
+# Warm executable pages, compiler files, and the fixture outside measurement.
+make --no-print-directory -s -f "$makefile" -j "$workers" STEPS="$warmup_steps"
+
+start_ns=$(date +%s%N)
+make --no-print-directory -s -f "$makefile" -j "$workers" STEPS="$steps"
+end_ns=$(date +%s%N)
+elapsed_ns=$((end_ns - start_ns))
+
+elapsed_seconds=$(awk -v value="$elapsed_ns" 'BEGIN { printf "%.9f", value / 1000000000 }')
+steps_per_second=$(awk -v count="$steps" -v value="$elapsed_ns" \
+    'BEGIN { printf "%.6f", count * 1000000000 / value }')
+elapsed_per_step_us=$(awk -v count="$steps" -v value="$elapsed_ns" \
+    'BEGIN { printf "%.3f", value / count / 1000 }')
+
+printf 'steps_per_second=%s;completed=%s;failures=0;elapsed_seconds=%s;elapsed_per_step_us=%s;workers=%s;task=gnu_make_cc_syntax;\n' \
+    "$steps_per_second" "$steps" "$elapsed_seconds" "$elapsed_per_step_us" "$workers"

--- a/bm-external/ci-fanout/ci-step.c
+++ b/bm-external/ci-fanout/ci-step.c
@@ -4,12 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static uint64_t rotate_left(uint64_t value, unsigned int shift)
+static uint64_t
+rotate_left(uint64_t value, unsigned int shift)
 {
     return (value << shift) | (value >> (64U - shift));
 }
 
-uint64_t validate_ci_manifest(const unsigned char *data, size_t length)
+uint64_t
+validate_ci_manifest(const unsigned char *data, size_t length)
 {
     uint64_t checksum = UINT64_C(0xcbf29ce484222325);
 

--- a/bm-external/ci-fanout/ci-step.c
+++ b/bm-external/ci-fanout/ci-step.c
@@ -1,0 +1,21 @@
+// Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <stddef.h>
+#include <stdint.h>
+
+static uint64_t rotate_left(uint64_t value, unsigned int shift)
+{
+    return (value << shift) | (value >> (64U - shift));
+}
+
+uint64_t validate_ci_manifest(const unsigned char *data, size_t length)
+{
+    uint64_t checksum = UINT64_C(0xcbf29ce484222325);
+
+    for (size_t i = 0; i < length; i++) {
+        checksum ^= data[i];
+        checksum = rotate_left(checksum, 7U) * UINT64_C(0x100000001b3);
+    }
+    return checksum;
+}

--- a/bm-external/memcg-net-fanout/enter-cgroup.sh
+++ b/bm-external/memcg-net-fanout/enter-cgroup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+group=$1
+shift
+case "$group" in
+    /sys/fs/cgroup/csb-memcg-net-[0-9]*/client-[0-9]*) ;;
+    *) echo "Refusing unexpected cgroup path: $group" >&2; exit 2 ;;
+esac
+
+printf '%s\n' "$$" >"$group/cgroup.procs"
+exec "$@"

--- a/bm-external/memcg-net-fanout/memcg-net-fanout.sh
+++ b/bm-external/memcg-net-fanout/memcg-net-fanout.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+workers=1
+duration=5
+
+usage()
+{
+    echo "Usage: $0 [--workers N] [--duration N]" >&2
+}
+
+require_uint()
+{
+    case "$2" in ''|*[!0-9]*) echo "$1 must be a positive integer" >&2; exit 2;; esac
+    [ "$2" -ge 1 ] || { echo "$1 must be a positive integer" >&2; exit 2; }
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --workers) [ "$#" -ge 2 ] || { usage; exit 2; }; workers=$2; shift 2 ;;
+        --duration) [ "$#" -ge 2 ] || { usage; exit 2; }; duration=$2; shift 2 ;;
+        *) usage; exit 2 ;;
+    esac
+done
+require_uint --workers "$workers"
+require_uint --duration "$duration"
+[ "$workers" -le 128 ] || { echo "--workers must not exceed 128" >&2; exit 2; }
+
+for command in iperf3 python3 sudo date mktemp; do
+    command -v "$command" >/dev/null 2>&1 || {
+        echo "Required command is unavailable: $command" >&2
+        exit 1
+    }
+done
+sudo -n true
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cgroup_root=/sys/fs/cgroup/csb-memcg-net-$$
+tmpdir=$(mktemp -d /tmp/csb-memcg-net.XXXXXX)
+server_pids=
+client_pids=
+
+cleanup()
+{
+    for pid in $client_pids $server_pids; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    i=1
+    while [ "$i" -le "$workers" ]; do
+        sudo -n rmdir "$cgroup_root/client-$i" 2>/dev/null || true
+        i=$((i + 1))
+    done
+    sudo -n rmdir "$cgroup_root" 2>/dev/null || true
+    rm -f "$tmpdir"/*.json "$tmpdir"/*.log
+    rmdir "$tmpdir" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+sudo -n mkdir "$cgroup_root"
+i=1
+while [ "$i" -le "$workers" ]; do
+    sudo -n mkdir "$cgroup_root/client-$i"
+    port=$((5200 + i))
+    iperf3 -s -1 -p "$port" >"$tmpdir/server-$i.log" 2>&1 &
+    server_pids="$server_pids $!"
+    i=$((i + 1))
+done
+sleep 1
+
+start_ns=$(date +%s%N)
+i=1
+while [ "$i" -le "$workers" ]; do
+    port=$((5200 + i))
+    sudo -n "$script_dir/enter-cgroup.sh" "$cgroup_root/client-$i" \
+        iperf3 -c 127.0.0.1 -p "$port" -R -t "$duration" -J \
+        >"$tmpdir/client-$i.json" 2>"$tmpdir/client-$i.log" &
+    client_pids="$client_pids $!"
+    i=$((i + 1))
+done
+
+failures=0
+for pid in $client_pids; do
+    wait "$pid" || failures=$((failures + 1))
+done
+client_pids=
+end_ns=$(date +%s%N)
+
+metrics=$(python3 - "$tmpdir" "$workers" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+expected = int(sys.argv[2])
+total = 0.0
+complete = 0
+for path in root.glob("client-*.json"):
+    try:
+        data = json.loads(path.read_text())
+        total += float(data["end"]["sum_received"]["bits_per_second"])
+        complete += 1
+    except (OSError, ValueError, KeyError, TypeError):
+        pass
+print(f"{total / 1e9:.6f} {complete} {expected - complete}")
+PY
+)
+set -- $metrics
+aggregate_gbps=$1
+completed=$2
+parse_failures=$3
+failures=$((failures + parse_failures))
+elapsed_ns=$((end_ns - start_ns))
+elapsed_seconds=$(python3 -c "print(f'{$elapsed_ns / 1e9:.9f}')")
+gbps_per_client=$(python3 -c "print(f'{$aggregate_gbps / $workers:.6f}')")
+
+printf 'aggregate_gbps=%s;gbps_per_client=%s;clients_completed=%s;failures=%s;elapsed_seconds=%s;workers=%s;tool=iperf3_reverse_loopback;\n' \
+    "$aggregate_gbps" "$gbps_per_client" "$completed" "$failures" \
+    "$elapsed_seconds" "$workers"
+[ "$failures" -eq 0 ]

--- a/config/bm-external/active-mm-fsopen.json
+++ b/config/bm-external/active-mm-fsopen.json
@@ -1,0 +1,61 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent workers",
+      "y": "operations_per_second",
+      "y_lbl": "fsopen lookups/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Filesystem type fsopen lookup"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    },
+    "name": "active-mm-fsopen"
+  },
+  "applications": [
+    {
+      "path": "bm-external/active-mm-scalability",
+      "name": "active-mm-scalability",
+      "args": "fsopen {threads} {duration}"
+    }
+  ],
+  "plugins": [
+    {
+      "name": "sudo",
+      "exec_time": "with"
+    }
+  ]
+}

--- a/config/bm-external/active-mm-netns.json
+++ b/config/bm-external/active-mm-netns.json
@@ -1,0 +1,61 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent workers",
+      "y": "operations_per_second",
+      "y_lbl": "Namespaces/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Network namespace lifecycle"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    },
+    "name": "active-mm-netns"
+  },
+  "applications": [
+    {
+      "path": "bm-external/active-mm-scalability",
+      "name": "active-mm-scalability",
+      "args": "netns {threads} {duration}"
+    }
+  ],
+  "plugins": [
+    {
+      "name": "sudo",
+      "exec_time": "with"
+    }
+  ]
+}

--- a/config/bm-external/active-mm-pivot-root.json
+++ b/config/bm-external/active-mm-pivot-root.json
@@ -1,0 +1,61 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent workers",
+      "y": "operations_per_second",
+      "y_lbl": "Pivot operations/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Private mount namespace pivot_root lifecycle"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    },
+    "name": "active-mm-pivot-root"
+  },
+  "applications": [
+    {
+      "path": "bm-external/active-mm-scalability",
+      "name": "active-mm-scalability",
+      "args": "pivot-root {threads} {duration}"
+    }
+  ],
+  "plugins": [
+    {
+      "name": "sudo",
+      "exec_time": "with"
+    }
+  ]
+}

--- a/config/bm-external/active-mm-proc-filesystems.json
+++ b/config/bm-external/active-mm-proc-filesystems.json
@@ -1,0 +1,61 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent workers",
+      "y": "operations_per_second",
+      "y_lbl": "Reads/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Filesystem registry enumeration"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    },
+    "name": "active-mm-proc-filesystems"
+  },
+  "applications": [
+    {
+      "path": "bm-external/active-mm-scalability",
+      "name": "active-mm-scalability",
+      "args": "proc-filesystems {threads} {duration}"
+    }
+  ],
+  "plugins": [
+    {
+      "name": "sudo",
+      "exec_time": "with"
+    }
+  ]
+}

--- a/config/bm-external/active-mm-uidhash-shared.json
+++ b/config/bm-external/active-mm-uidhash-shared.json
@@ -1,0 +1,61 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent workers",
+      "y": "operations_per_second",
+      "y_lbl": "UID transitions/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Shared UID bucket control"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    },
+    "name": "active-mm-uid-shared"
+  },
+  "applications": [
+    {
+      "path": "bm-external/active-mm-scalability",
+      "name": "active-mm-scalability",
+      "args": "uid-shared {threads} {duration}"
+    }
+  ],
+  "plugins": [
+    {
+      "name": "sudo",
+      "exec_time": "with"
+    }
+  ]
+}

--- a/config/bm-external/active-mm-uidhash.json
+++ b/config/bm-external/active-mm-uidhash.json
@@ -1,0 +1,61 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent workers",
+      "y": "operations_per_second",
+      "y_lbl": "UID transitions/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Independent UID buckets"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "core_assignment_policy": {
+      "cpu_order": "asc",
+      "pack_group": "none",
+      "one_cpu_per_core": true
+    },
+    "name": "active-mm-uid-unique"
+  },
+  "applications": [
+    {
+      "path": "bm-external/active-mm-scalability",
+      "name": "active-mm-scalability",
+      "args": "uid-unique {threads} {duration}"
+    }
+  ],
+  "plugins": [
+    {
+      "name": "sudo",
+      "exec_time": "with"
+    }
+  ]
+}

--- a/config/bm-external/ci-fanout-micro.json
+++ b/config/bm-external/ci-fanout-micro.json
@@ -1,0 +1,54 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent launchers",
+      "y": "fork_execs_per_second",
+      "y_lbl": "Completed fork/execs/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Warm CI runner fork/exec throughput"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent launchers",
+      "y": "mean_fork_exec_us",
+      "y_lbl": "Mean fork/exec latency (us)",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Warm CI runner fork/exec latency"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": [],
+      "container": []
+    },
+    "threads": {
+      "values": [
+        [1, 8, 32, 64, 128]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [1]
+      ]
+    },
+    "core_count": 128,
+    "image": "ubuntu:latest",
+    "name": "ci-fanout-micro"
+  },
+  "applications": [
+    {
+      "path": "bm-external/ci-fanout",
+      "name": "ci-fanout-micro",
+      "args": "--workers {threads} --duration {duration} --memory-mib 256"
+    }
+  ]
+}

--- a/config/bm-external/ci-fanout-micro.json
+++ b/config/bm-external/ci-fanout-micro.json
@@ -30,14 +30,22 @@
     },
     "threads": {
       "values": [
-        [1, 8, 32, 64, 128]
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
       ]
     }
   },
   "containers": {
     "container_list": {
       "values": [
-        [1]
+        [
+          1
+        ]
       ]
     },
     "core_count": 128,

--- a/config/bm-external/ci-fanout.json
+++ b/config/bm-external/ci-fanout.json
@@ -1,0 +1,62 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent CI steps",
+      "y": "steps_per_second",
+      "y_lbl": "Completed CI steps/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Warm CI runner shell-step throughput"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent CI steps",
+      "y": "elapsed_seconds",
+      "y_lbl": "Fixed-work elapsed time (s)",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Warm CI runner fixed-work completion time"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 10,
+    "repeat": 5,
+    "exec_env": {
+      "native": [],
+      "container": []
+    },
+    "threads": {
+      "values": [
+        [
+          1,
+          8,
+          32,
+          64,
+          128
+        ]
+      ]
+    }
+  },
+  "containers": {
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
+    "core_count": 128,
+    "image": "ubuntu:latest",
+    "name": "ci-fanout"
+  },
+  "applications": [
+    {
+      "path": "bm-external/ci-fanout",
+      "name": "ci-fanout.sh",
+      "args": "--workers {threads} --steps 1024 --warmup-steps 32"
+    }
+  ]
+}

--- a/config/bm-external/memcg-net-fanout.json
+++ b/config/bm-external/memcg-net-fanout.json
@@ -1,0 +1,47 @@
+{
+  "plots": [
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent tenant flows",
+      "y": "aggregate_gbps",
+      "y_lbl": "Aggregate reverse-loopback Gbit/s",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Multi-cgroup network receive throughput"
+    },
+    {
+      "x": "nb_threads",
+      "x_lbl": "Concurrent tenant flows",
+      "y": "gbps_per_client",
+      "y_lbl": "Gbit/s per tenant",
+      "hue": "execution_type",
+      "hue_lbl": "Environment",
+      "type": "mean",
+      "title": "Multi-cgroup network receive efficiency"
+    }
+  ],
+  "benchmark_config": {
+    "duration": 5,
+    "repeat": 5,
+    "exec_env": {
+      "native": []
+    },
+    "threads": {
+      "values": [[1, 8, 16, 32, 64]]
+    }
+  },
+  "containers": {
+    "container_list": {"values": [[1]]},
+    "core_count": 128,
+    "image": "ubuntu:latest",
+    "name": "memcg-net-fanout"
+  },
+  "applications": [
+    {
+      "path": "bm-external/memcg-net-fanout",
+      "name": "memcg-net-fanout.sh",
+      "args": "--workers {threads} --duration 5"
+    }
+  ]
+}

--- a/config/bm-external/memcg-net-fanout.json
+++ b/config/bm-external/memcg-net-fanout.json
@@ -28,11 +28,25 @@
       "native": []
     },
     "threads": {
-      "values": [[1, 8, 16, 32, 64]]
+      "values": [
+        [
+          1,
+          8,
+          16,
+          32,
+          64
+        ]
+      ]
     }
   },
   "containers": {
-    "container_list": {"values": [[1]]},
+    "container_list": {
+      "values": [
+        [
+          1
+        ]
+      ]
+    },
     "core_count": 128,
     "image": "ubuntu:latest",
     "name": "memcg-net-fanout"

--- a/doc/bm-external/active-mm-scalability.md
+++ b/doc/bm-external/active-mm-scalability.md
@@ -24,6 +24,9 @@ workers and five repetitions:
 - `active-mm-proc-filesystems.json` repeatedly enumerates
   `/proc/filesystems`. The last two configs target the read-mostly filesystem
   type registry through independent syscall paths.
+- `active-mm-pivot-root.json` creates private mount namespaces and pivots each
+  onto a fresh tmpfs root. It targets the system-wide `chroot_fs_refs()` scan
+  used while container runtimes install a new root filesystem.
 
 Run a config, for example, with:
 
@@ -42,6 +45,8 @@ Keep the focused result beside a relatable workload:
 - Network namespace and kernfs: `config/bm-external/cgroups/runc.json` and the
   container lifecycle harness.
 - Filesystem registry: runc/container lifecycle and `stress-ng --procfs`.
+- Pivot root: runc lifecycle and the container harness, with fork/exit as the
+  registry-maintenance no-regression control.
 
 Do not claim a real-workload improvement from an attribution benchmark alone.
 Accept a kernel change only after alternating-boot A/B runs show both a

--- a/doc/bm-external/active-mm-scalability.md
+++ b/doc/bm-external/active-mm-scalability.md
@@ -1,0 +1,48 @@
+# Active-MM scalability attribution benchmarks
+
+These native benchmarks isolate global synchronization found while profiling
+parallel container creation and teardown. They complement, rather than replace,
+the real workloads already in CSB.
+
+Build the shared benchmark executable with:
+
+```sh
+scripts/bm-external/active-mm-scalability/configure.sh
+```
+
+The configs use one native execution unit with 1, 8, 32, 64, or 128 internal
+workers and five repetitions:
+
+- `active-mm-uidhash.json` repeatedly changes each worker to independent real
+  UIDs and back while retaining effective and saved UID 0. It targets
+  `uidhash_lock`; use `active-mm-uidhash-shared.json` as the same-bucket
+  correctness and no-improvement control.
+- `active-mm-netns.json` creates short-lived network namespaces and verifies
+  `/sys/class/net/lo`. It exercises sysfs/kernfs creation during network
+  namespace setup.
+- `active-mm-fsopen.json` repeatedly resolves `tmpfs` through `fsopen(2)`.
+- `active-mm-proc-filesystems.json` repeatedly enumerates
+  `/proc/filesystems`. The last two configs target the read-mostly filesystem
+  type registry through independent syscall paths.
+
+Run a config, for example, with:
+
+```sh
+scripts/run-single.sh config/bm-external/active-mm-uidhash.json
+```
+
+The configs use the `sudo` wrapper because UID transitions, network namespace
+creation, and `fsopen(2)` require privilege. Each operation validates its
+observable state and any failure makes the campaign point fail.
+
+Keep the focused result beside a relatable workload:
+
+- UID hash: rootless/multi-user container credential setup and
+  `stress-ng --set`.
+- Network namespace and kernfs: `config/bm-external/cgroups/runc.json` and the
+  container lifecycle harness.
+- Filesystem registry: runc/container lifecycle and `stress-ng --procfs`.
+
+Do not claim a real-workload improvement from an attribution benchmark alone.
+Accept a kernel change only after alternating-boot A/B runs show both a
+high-core throughput improvement and reduced contention in the intended lock.

--- a/doc/bm-external/ci-fanout.md
+++ b/doc/bm-external/ci-fanout.md
@@ -1,0 +1,52 @@
+# Warm CI runner fan-out benchmarks
+
+This paired external benchmark models a warm CI, package-build, or test runner
+that dispatches many short processes concurrently. It targets large systems
+where process creation and address-space teardown can limit job-dispatch
+throughput.
+
+## Actual workload
+
+`config/bm-external/ci-fanout.json` uses existing production tools: GNU
+`make`, `/bin/sh`, and the system C compiler. A fixed make DAG runs 1,024
+independent `cc -fsyntax-only` checks at 1, 8, 32, 64, and 128-way
+parallelism. The shell wrapper only warms the tools, measures the fixed-work
+run, and emits CSB key/value output.
+
+The primary metric is completed compile-validation steps per second. The
+benchmark also reports fixed-work elapsed time, average elapsed contribution
+per step, completed steps, and failures. A valid comparison requires exactly
+1,024 completed steps and zero failures at every point.
+
+## Mechanism companion
+
+`config/bm-external/ci-fanout-micro.json` keeps a focused attribution test next
+to the actual workload. A memory-resident coordinator faults in a 256 MiB cache
+and uses 1, 8, 32, 64, or 128 threads to perform explicit `fork()` plus
+`execve("/bin/true")` cycles. It reports aggregate fork/exec throughput and
+latency. This test is not the real-world result; it helps determine whether a
+change in the make/compiler workload follows the expected process-MM mechanism.
+
+Build the companion and run both configs with:
+
+```bash
+scripts/bm-external/ci-fanout/configure.sh
+scripts/run-single.sh config/bm-external/ci-fanout-micro.json
+scripts/run-single.sh config/bm-external/ci-fanout.json
+```
+
+Both configs run natively and inside `ubuntu:latest`. CSB starts the container
+before releasing its workload barrier, so image pull and container creation
+are outside the timed region. The supplied configs target a 128-CPU host and
+repeat every point five times.
+
+For cross-kernel comparisons, pin the same CPUs, use the same image and
+compiler, randomize kernel order, and retain thermal/frequency metadata. Do not
+compare runs whose fixture, toolchain, step count, memory size, worker set, or
+execution environment differs.
+
+The actual workload is still narrower than a complete software build. It
+answers whether a kernel improves dispatch capacity for a shell- and
+compiler-heavy runner; it does not predict CPU-bound compile throughput,
+long-running services, or container cold-start time. Measure container
+lifecycle separately when creation itself is part of the deployment question.

--- a/doc/bm-external/memcg-net-fanout.md
+++ b/doc/bm-external/memcg-net-fanout.md
@@ -1,0 +1,28 @@
+# Multi-cgroup network fanout
+
+This benchmark uses the existing `iperf3` tool to model a multi-tenant host
+receiving traffic for many containers or services. Each reverse-loopback
+client is placed in its own cgroup v2 memory cgroup, so network receive work
+mixes memory-accounting charges for distinct tenants on the same CPUs.
+
+The primary metric is aggregate received Gbit/s. `gbps_per_client`, completed
+clients, failures, and elapsed time guard against false throughput wins. The
+1, 8, 16, 32, and 64-client points are repeated five times. Setup, cgroup
+creation, and server startup happen before the internal timed interval.
+
+This is the real-tool companion to `memcg_stock_switch`: the focused test
+pins several memory-cgroup allocation streams to each CPU, while this workload
+exercises the same mixed-cgroup charge-cache behavior through actual TCP
+receive paths. It specifically evaluates per-CPU multi-memcg charge stocks;
+it is not a general internet or NIC benchmark because loopback deliberately
+removes physical-network variance.
+
+Run it with:
+
+```sh
+scripts/bm-external/memcg-net-fanout/configure.sh
+scripts/run-single.sh config/bm-external/memcg-net-fanout.json
+```
+
+The runner needs passwordless `sudo` to create and remove its uniquely named
+cgroups. The helper validates the exact cgroup prefix before moving a process.

--- a/scripts/bm-external/active-mm-scalability/configure.sh
+++ b/scripts/bm-external/active-mm-scalability/configure.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+src="$root/bm-external/active-mm-scalability/active-mm-scalability.c"
+out="$root/bm-external/active-mm-scalability/active-mm-scalability"
+
+${CC:-cc} -O2 -g -Wall -Wextra -Werror -o "$out" "$src"

--- a/scripts/bm-external/ci-fanout/configure.sh
+++ b/scripts/bm-external/ci-fanout/configure.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+src="$root/bm-external/ci-fanout/ci-fanout-micro.c"
+out="$root/bm-external/ci-fanout/ci-fanout-micro"
+
+${CC:-cc} -O2 -g -Wall -Wextra -Werror -pthread -o "$out" "$src"

--- a/scripts/bm-external/memcg-net-fanout/configure.sh
+++ b/scripts/bm-external/memcg-net-fanout/configure.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright (C) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+chmod +x "$root/bm-external/memcg-net-fanout/memcg-net-fanout.sh"
+chmod +x "$root/bm-external/memcg-net-fanout/enter-cgroup.sh"
+command -v iperf3 >/dev/null 2>&1 || {
+    echo "iperf3 is required for memcg-net-fanout" >&2
+    exit 1
+}
+sudo -n true


### PR DESCRIPTION
## Summary

- add a GNU make and compiler fan-out workload for warm high-density CI runners
- keep an explicit `fork()` and `execve()` mechanism benchmark beside the actual workload
- provide native and warm-container CSB configurations for 1, 8, 32, 64, and 128 workers
- document scope, validity checks, and cross-kernel comparison requirements

The primary workload runs a fixed DAG of 1,024 `cc -fsyntax-only` validation jobs. The companion keeps a 256 MiB parent resident while concurrent workers execute `/bin/true`, helping attribute changes without treating the microbenchmark as the real-world result. Container creation and image pulling remain outside the measured region.

## Validation

- built the companion on node26/aarch64 with `-Wall -Wextra -Werror`
- completed native and container smoke runs at 1 and 4 workers for both configs, with zero failures
- generated CSV and HTML output for both configs
- traced the actual workload and observed process creation plus `execve()` activity
- verified invalid zero-worker arguments are rejected
- `35 passed` in the benchmark, container, and environment configuration tests
